### PR TITLE
Convert doc comments to rust format

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target


### PR DESCRIPTION
This crate has lots of great doc comments, but they were not
showing up in the doc.rs docs. This patch just reformats the
doc comments so that they will get picked up by `cargo doc`.