### PR TITLE
.NET version of library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+*.user
+bin/
+obj/

--- a/dotnet/QrCodeGenerator.sln
+++ b/dotnet/QrCodeGenerator.sln
@@ -5,10 +5,12 @@ VisualStudioVersion = 15.0.28307.271
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QrCodeGenerator", "QrCodeGenerator\QrCodeGenerator.csproj", "{36B0822E-28D7-43C7-BAF7-AF578E31E978}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QrCodeGeneratorTest", "QrCodeGeneratorTest\QrCodeGeneratorTest.csproj", "{81307EE7-7915-4D2D-8F71-495F239FD266}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QrCodeGeneratorTest", "QrCodeGeneratorTest\QrCodeGeneratorTest.csproj", "{81307EE7-7915-4D2D-8F71-495F239FD266}"
 	ProjectSection(ProjectDependencies) = postProject
 		{36B0822E-28D7-43C7-BAF7-AF578E31E978} = {36B0822E-28D7-43C7-BAF7-AF578E31E978}
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QrCodeGeneratorDemo", "QrCodeGeneratorDemo\QrCodeGeneratorDemo.csproj", "{D7FE0375-D44E-4F43-8AFC-DAF31848D1EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,6 +26,10 @@ Global
 		{81307EE7-7915-4D2D-8F71-495F239FD266}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81307EE7-7915-4D2D-8F71-495F239FD266}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81307EE7-7915-4D2D-8F71-495F239FD266}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7FE0375-D44E-4F43-8AFC-DAF31848D1EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7FE0375-D44E-4F43-8AFC-DAF31848D1EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7FE0375-D44E-4F43-8AFC-DAF31848D1EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7FE0375-D44E-4F43-8AFC-DAF31848D1EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/dotnet/QrCodeGenerator.sln
+++ b/dotnet/QrCodeGenerator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.271
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QrCodeGenerator", "QrCodeGenerator\QrCodeGenerator.csproj", "{36B0822E-28D7-43C7-BAF7-AF578E31E978}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QrCodeGeneratorTest", "QrCodeGeneratorTest\QrCodeGeneratorTest.csproj", "{81307EE7-7915-4D2D-8F71-495F239FD266}"
+	ProjectSection(ProjectDependencies) = postProject
+		{36B0822E-28D7-43C7-BAF7-AF578E31E978} = {36B0822E-28D7-43C7-BAF7-AF578E31E978}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{36B0822E-28D7-43C7-BAF7-AF578E31E978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36B0822E-28D7-43C7-BAF7-AF578E31E978}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36B0822E-28D7-43C7-BAF7-AF578E31E978}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36B0822E-28D7-43C7-BAF7-AF578E31E978}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81307EE7-7915-4D2D-8F71-495F239FD266}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81307EE7-7915-4D2D-8F71-495F239FD266}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81307EE7-7915-4D2D-8F71-495F239FD266}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81307EE7-7915-4D2D-8F71-495F239FD266}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {256EFBB5-C259-4422-BE66-29B9FF4BF92F}
+	EndGlobalSection
+EndGlobal

--- a/dotnet/QrCodeGenerator/BitArrayExtensions.cs
+++ b/dotnet/QrCodeGenerator/BitArrayExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -27,38 +27,39 @@ using System.Collections;
 namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
-    /// Provides extension methods for the <see cref="BitArray"/> class.
+    /// Extension methods for the <see cref="BitArray"/> class.
     /// </summary>
     public static class BitArrayExtensions
     {
 
         /// <summary>
-        /// Appends the specified number of low-order bits of the specified value to this
-        /// bit array. Requires 0 &#x2264; len &#x2264; 31 and 0 &#x2264; val &lt; 2<sup>len</sup>.
+        /// Appends the specified number bits of the specified value to this bit array.
+        /// <para>
+        /// The least significant bits of the specified value are added. They are appended in reverse order,
+        /// from the most significant to the least significant one, i.e. bits 0 to <i>len-1</i>
+        /// are appended in the order <i>len-1</i>, <i>len-2</i> ... 1, 0.
+        /// </para>
+        /// <para>
+        /// Requires 0 &#x2264; len &#x2264; 31, and 0 &#x2264; val &lt; 2<sup>len</sup>.
+        /// </para>
         /// </summary>
-        /// <param name="bitArray">this bit array</param>
-        /// <param name="val">the value to append</param>
-        /// <param name="len">the number of low-order bits in the value to take</param>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if the value or number of bits is out of range</exception>
-        /// <exception cref="InvalidOperationException">Thrown if appending the data would make bit length exceed <see cref="int.MaxValue"/></exception>
+        /// <param name="bitArray">The BitArray instance that this method extends.</param>
+        /// <param name="val">The value to append.</param>
+        /// <param name="len">The number of low-order bits in the value to append.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Value or number of bits is out of range.</exception>
         public static void AppendBits(this BitArray bitArray, uint val, int len)
         {
-            if (len < 0 || len > 31 || (val >> len) != 0)
+            if (len < 0 || len > 31 || val >> len != 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(len), "'len' out of range");
             }
 
-            if (len < 0 || len > 31 || (val >> len) != 0)
+            if (len < 0 || len > 31 || val >> len != 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(val), "'val' out of range");
             }
 
             int bitLength = bitArray.Length;
-            if (int.MaxValue - bitLength < len)
-            {
-                throw new InvalidOperationException("Maximum length reached");
-            }
-
             bitArray.Length = bitLength + len;
             uint mask = 1U << (len - 1);
             for (int i = bitLength; i < bitLength + len; i++) // Append bit by bit
@@ -74,21 +75,15 @@ namespace IO.Nayuki.QrCodeGen
 
 
         /// <summary>
-        /// Appends the content of the specified bit array to this array.
+        /// Appends the content of the specified bit array to the end of this array.
         /// </summary>
-        /// <param name="bitArray">this bit array</param>
-        /// <param name="otherArray">the bit array whose data to append (not <c>null</c>)</param>
-        /// <exception cref="ArgumentNullException">Thrown if the bit array is <c>null</c></exception>
-        /// <exception cref="InvalidOperationException">Thrown if appending the data would make the bit length exceed <see cref="int.MaxValue"/></exception>
+        /// <param name="bitArray">The BitArray instance that this method extends.</param>
+        /// <param name="otherArray">The bit array to append</param>
+        /// <exception cref="ArgumentNullException">If <c>bitArray</c> is <c>null</c>.</exception>
         public static void AppendData(this BitArray bitArray, BitArray otherArray)
         {
             Objects.RequireNonNull(otherArray);
             int bitLength = bitArray.Length;
-            if (int.MaxValue - bitLength < otherArray.Length)
-            {
-                throw new InvalidOperationException("Maximum length reached");
-            }
-
             bitArray.Length = bitLength + otherArray.Length;
             for (int i = 0; i < otherArray.Length; i++, bitLength++)  // Append bit by bit
             {

--- a/dotnet/QrCodeGenerator/BitArrayExtensions.cs
+++ b/dotnet/QrCodeGenerator/BitArrayExtensions.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Collections;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// Provides extension methods for the <see cref="BitArray"/> class.

--- a/dotnet/QrCodeGenerator/BitArrayExtensions.cs
+++ b/dotnet/QrCodeGenerator/BitArrayExtensions.cs
@@ -1,0 +1,104 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System;
+using System.Collections;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="BitArray"/> class.
+    /// </summary>
+    public static class BitArrayExtensions
+    {
+
+        /// <summary>
+        /// Appends the specified number of low-order bits of the specified value to this
+        /// bit array. Requires 0 &#x2264; len &#x2264; 31 and 0 &#x2264; val &lt; 2<sup>len</sup>.
+        /// </summary>
+        /// <param name="bitArray">this bit array</param>
+        /// <param name="val">the value to append</param>
+        /// <param name="len">the number of low-order bits in the value to take</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the value or number of bits is out of range</exception>
+        /// <exception cref="InvalidOperationException">Thrown if appending the data would make bit length exceed <see cref="int.MaxValue"/></exception>
+        public static void AppendBits(this BitArray bitArray, uint val, int len)
+        {
+            if (len < 0 || len > 31 || (val >> len) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(len), "'len' out of range");
+            }
+
+            if (len < 0 || len > 31 || (val >> len) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(val), "'val' out of range");
+            }
+
+            int bitLength = bitArray.Length;
+            if (int.MaxValue - bitLength < len)
+            {
+                throw new InvalidOperationException("Maximum length reached");
+            }
+
+            bitArray.Length = bitLength + len;
+            uint mask = 1U << (len - 1);
+            for (int i = bitLength; i < bitLength + len; i++) // Append bit by bit
+            {
+                if ((val & mask) != 0)
+                {
+                    bitArray.Set(i, true);
+                }
+
+                mask >>= 1;
+            }
+        }
+
+
+        /// <summary>
+        /// Appends the content of the specified bit array to this array.
+        /// </summary>
+        /// <param name="bitArray">this bit array</param>
+        /// <param name="otherArray">the bit array whose data to append (not <c>null</c>)</param>
+        /// <exception cref="ArgumentNullException">Thrown if the bit array is <c>null</c></exception>
+        /// <exception cref="InvalidOperationException">Thrown if appending the data would make the bit length exceed <see cref="int.MaxValue"/></exception>
+        public static void AppendData(this BitArray bitArray, BitArray otherArray)
+        {
+            Objects.RequireNonNull(otherArray);
+            int bitLength = bitArray.Length;
+            if (int.MaxValue - bitLength < otherArray.Length)
+            {
+                throw new InvalidOperationException("Maximum length reached");
+            }
+
+            bitArray.Length = bitLength + otherArray.Length;
+            for (int i = 0; i < otherArray.Length; i++, bitLength++)  // Append bit by bit
+            {
+                if (otherArray[i])
+                {
+                    bitArray.Set(bitLength, true);
+                }
+            }
+        }
+
+    }
+}
+

--- a/dotnet/QrCodeGenerator/DataTooLongException.cs
+++ b/dotnet/QrCodeGenerator/DataTooLongException.cs
@@ -1,0 +1,58 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+using System;
+using System.Collections.Generic;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// Thrown when the supplied data does not fit any QR Code version.
+    /// </summary>
+    /// <remarks>
+    /// Ways to handle this exception include:
+    /// <ul>
+    ///   <li>Decrease the error correction level if it was greater than <see cref="QrCode.Ecc.Low"/></li>
+    ///   <li><p>If the advanced <see cref=QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc, int, int, int, bool)"/>
+    ///     function or the <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/> function was called,
+    ///     then increase the maxVersion argument if it was less than <see cref="QrCode.MaxVersion"/>.
+    ///     (This advice does not apply to the other factory functions because they search all versions up to
+    ///     <see cref="QrCode.MaxVersion"/></li>
+    ///   <li>Split the text data into better or optimal segments in order to reduce the number of bits required.
+    ///     (See <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/>.)</li>
+    ///   <li>Change the text or binary data to be shorter.</li>
+    ///   <li>Change the text to fit the character set of a particular segment mode (e.g. alphanumeric).</li>
+    ///   <li>Propagate the error upward to the caller/user.</li>
+    /// </ul>
+    /// </remarks>
+    /// <seealso cref="QrCode.EncodeText(string, QrCode.Ecc)"/>
+    /// <seealso cref="QrCode.EncodeBinary(byte[], QrCode.Ecc)"/>
+    /// <seealso cref="QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc)"/>
+    /// <seealso cref="QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc, int, int, int, bool)"/>
+    /// <seealso cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/>
+    public class DataTooLongException : ArgumentException
+    {
+        public DataTooLongException(string message)
+            : base(message)
+        { }
+    }
+}

--- a/dotnet/QrCodeGenerator/DataTooLongException.cs
+++ b/dotnet/QrCodeGenerator/DataTooLongException.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -26,31 +26,34 @@ using System.Collections.Generic;
 namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
-    /// Thrown when the supplied data does not fit any QR Code version.
+    /// The exception that is thrown when the supplied data does not fit in the QR code.
     /// </summary>
     /// <remarks>
     /// Ways to handle this exception include:
     /// <ul>
-    ///   <li>Decrease the error correction level if it was greater than <see cref="QrCode.Ecc.Low"/></li>
-    ///   <li><p>If the advanced <see cref=QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc, int, int, int, bool)"/>
-    ///     function or the <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/> function was called,
-    ///     then increase the maxVersion argument if it was less than <see cref="QrCode.MaxVersion"/>.
-    ///     (This advice does not apply to the other factory functions because they search all versions up to
-    ///     <see cref="QrCode.MaxVersion"/></li>
-    ///   <li>Split the text data into better or optimal segments in order to reduce the number of bits required.
-    ///     (See <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/>.)</li>
-    ///   <li>Change the text or binary data to be shorter.</li>
+    ///   <li>Decrease the error correction level (if it was greater than <see cref="QrCode.Ecc.Low"/>)</li>
+    ///   <li>Increase the <c>maxVersion</c> argument (if it was less than <see cref="QrCode.MaxVersion"/>).
+    ///       This advice applies to the advanced factory functions
+    ///       <see cref="QrCode.EncodeSegments"/> and
+    ///       <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/> only.
+    ///       Other factory functions automatically try all versions up to <see cref="QrCode.MaxVersion"/>.</li>
+    ///   <li>Split the text into several segments and encode them using different encoding modes
+    ///     (see <see cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/>.)</li>
+    ///   <li>Make the text or binary data shorter.</li>
     ///   <li>Change the text to fit the character set of a particular segment mode (e.g. alphanumeric).</li>
-    ///   <li>Propagate the error upward to the caller/user.</li>
+    ///   <li>Reject the data and notify the caller/user.</li>
     /// </ul>
     /// </remarks>
     /// <seealso cref="QrCode.EncodeText(string, QrCode.Ecc)"/>
     /// <seealso cref="QrCode.EncodeBinary(byte[], QrCode.Ecc)"/>
-    /// <seealso cref="QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc)"/>
     /// <seealso cref="QrCode.EncodeSegments(List{QrSegment}, QrCode.Ecc, int, int, int, bool)"/>
     /// <seealso cref="QrSegmentAdvanced.MakeSegmentsOptimally(string, QrCode.Ecc, int, int)"/>
     public class DataTooLongException : ArgumentException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataTooLongException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public DataTooLongException(string message)
             : base(message)
         { }

--- a/dotnet/QrCodeGenerator/DataTooLongException.cs
+++ b/dotnet/QrCodeGenerator/DataTooLongException.cs
@@ -23,7 +23,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// Thrown when the supplied data does not fit any QR Code version.

--- a/dotnet/QrCodeGenerator/Objects.cs
+++ b/dotnet/QrCodeGenerator/Objects.cs
@@ -1,0 +1,39 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    internal class Objects
+    {
+        internal static T RequireNonNull<T>(T arg)
+        {
+            if (arg == null)
+            {
+                throw new ArgumentNullException();
+            }
+            return arg;
+        }
+    }
+}

--- a/dotnet/QrCodeGenerator/Objects.cs
+++ b/dotnet/QrCodeGenerator/Objects.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -25,8 +25,21 @@ using System;
 
 namespace IO.Nayuki.QrCodeGen
 {
+    /// <summary>
+    /// Helper functions to check for valid arguments.
+    /// </summary>
     internal class Objects
     {
+        /// <summary>
+        /// Ensures that the specified argument is <i>not null</i>.
+        /// <para>
+        /// Throws a <see cref="ArgumentNullException"/> exception if the argument is <c>null</c>.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">The type of the argument.</typeparam>
+        /// <param name="arg">The argument to check.</param>
+        /// <returns>Argument passed to function.</returns>
+        /// <exception cref="ArgumentNullException">The specified argument is <c>null</c>.</exception>
         internal static T RequireNonNull<T>(T arg)
         {
             if (arg == null)

--- a/dotnet/QrCodeGenerator/Objects.cs
+++ b/dotnet/QrCodeGenerator/Objects.cs
@@ -23,7 +23,7 @@
 
 using System;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     internal class Objects
     {

--- a/dotnet/QrCodeGenerator/QrCode.cs
+++ b/dotnet/QrCodeGenerator/QrCode.cs
@@ -966,7 +966,7 @@ namespace Io.Nayuki.QrCodeGen
         // Returns the number of 8-bit data (i.e. not error correction) codewords contained in any
         // QR Code of the given version number and error correction level, with remainder bits discarded.
         // This stateless pure function could be implemented as a (40*4)-cell lookup table.
-        private static int GetNumDataCodewords(int ver, Ecc ecl)
+        internal static int GetNumDataCodewords(int ver, Ecc ecl)
         {
             return GetNumRawDataModules(ver) / 8
                 - EccCodewordsPerBlock[ecl.Ordinal, ver]

--- a/dotnet/QrCodeGenerator/QrCode.cs
+++ b/dotnet/QrCodeGenerator/QrCode.cs
@@ -30,7 +30,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Text;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// A QR Code symbol, which is a type of two-dimension barcode.

--- a/dotnet/QrCodeGenerator/QrCode.cs
+++ b/dotnet/QrCodeGenerator/QrCode.cs
@@ -1,0 +1,1021 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// A QR Code symbol, which is a type of two-dimension barcode.
+    /// </summary>
+    /// <remarks>
+    /// <para>Invented by Denso Wave and described in the ISO/IEC 18004 standard.</para>
+    /// <para>araInstances of this class represent an immutable square grid of black and white cells.
+    /// The class provides static factory functions to create a QR Code from text or binary data.
+    /// The class covers the QR Code Model 2 specification, supporting all versions (sizes)
+    /// from 1 to 40, all 4 error correction levels, and 4 character encoding modes.</para>
+    /// <para>Ways to create a QR Code object:</para>
+    /// <ul>
+    ///   <li>High level: Take the payload data and call <see cref="EncodeText(string, Ecc)"/>
+    ///     or <see cref="EncodeBinary(byte[], Ecc)"/>.</li>
+    ///   <li>Mid level: Custom-make the list of <see cref="QrSegment"/>
+    ///     and call <see cref="EncodeSegments(List{QrSegment}, Ecc)"/> or
+    ///     <see cref="EncodeSegments(List{QrSegment}, Ecc, int, int, int, bool)"/></li>
+    ///   <li>Low level: Custom-make the array of data codeword bytes (including segment headers and
+    ///     final padding, excluding error correction codewords), supply the appropriate version number,
+    ///     and call the <see cref="QrCode(int, Ecc, byte[], int)"/>.</li>
+    /// </ul>
+    /// <para>(Note that all ways require supplying the desired error correction level.)</para>
+    /// </remarks>
+    /// <seealso cref="QrSegment"/>
+    public class QrCode
+    {
+        #region Static factory functions (high level)
+
+        /// <summary>
+        /// Returns a QR Code representing the specified Unicode text string at the specified error correction level.
+        /// </summary>
+        /// <remarks>
+        /// As a conservative upper bound, this function is guaranteed to succeed for strings that have 738 or fewer
+        /// Unicode code points(not UTF-16 code units) if the low error correction level is used.The smallest possible
+        /// QR Code version is automatically chosen for the output.The ECC level of the result may be higher than the
+        /// ecl argument if it can be done without increasing the version.
+        /// </remarks>
+        /// <param name="text">the text to be encoded (not <c>null</c>), which can be any Unicode string</param>
+        /// <param name="ecl">the error correction level to use (not <c>null</c>) (boostable)</param>
+        /// <returns>a QR Code (not <c>null</c>) representing the text</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the text or error correction level is <c>null</c></exception>
+        /// <exception cref="DataTooLongException">Thrown if the text fails to fit in the
+        /// largest version QR Code at the ECL, which means it is too long</exception>
+        public static QrCode EncodeText(string text, Ecc ecl)
+        {
+            Objects.RequireNonNull(text);
+            Objects.RequireNonNull(ecl);
+            List<QrSegment> segs = QrSegment.MakeSegments(text);
+            return EncodeSegments(segs, ecl);
+        }
+
+        /// <summary>
+        /// Returns a QR Code representing the specified binary data at the specified error correction level.
+        /// </summary>
+        /// <remarks>
+        /// This function always encodes using the binary segment mode, not any text mode. The maximum number of
+        /// bytes allowed is 2953. The smallest possible QR Code version is automatically chosen for the output.
+        /// The ECC level of the result may be higher than the ecl argument if it can be done without increasing the version.
+        /// </remarks>
+        /// <param name="data">the binary data to encode (not <c>null</c>)</param>
+        /// <param name="ecl">the error correction level to use (not <c>null</c>) (boostable)</param>
+        /// <returns>a QR Code (not <c>null</c>) representing the data</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the data or error correction level is <c>null</c></exception>
+        /// <exception cref="DataTooLongException">Thrown if the data fails to fit in the
+        /// largest version QR Code at the ECL, which means it is too long</exception>
+        public static QrCode EncodeBinary(byte[] data, Ecc ecl)
+        {
+            Objects.RequireNonNull(data);
+            Objects.RequireNonNull(ecl);
+            QrSegment seg = QrSegment.MakeBytes(data);
+            return EncodeSegments(new List<QrSegment> { seg }, ecl);
+        }
+
+        #endregion
+
+
+        #region Static factory functions (mid level)
+
+        /// <summary>
+        /// Returns a QR Code representing the specified segments at the specified error correction level.
+        /// </summary>
+        /// <remarks>
+        /// <para>The smallest possible QR Code version is automatically chosen for the output. The ECC level
+        /// of the result may be higher than the ecl argument if it can be done without increasing the version. </para>
+        /// <para>This function allows the user to create a custom sequence of segments that switches
+        /// between modes (such as alphanumeric and byte) to encode text in less space.</para>
+        /// <para>This is a mid-level API; the high-level API is <see cref="EncodeText(string, Ecc)"/>
+        /// and <see cref="EncodeBinary(byte[], Ecc)"/></para>
+        /// </remarks>
+        /// <param name="segs">the segments to encode</param>
+        /// <param name="ecl">the error correction level to use (not <c>null</c>) (boostable)</param>
+        /// <returns>a QR Code (not <c>null</c>) representing the segments</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the data or error correction level is <c>null</c></exception>
+        /// <exception cref="DataTooLongException">Thrown if the segments fail to fit in the
+        /// largest version QR Code at the ECL, which means it is too long</exception>
+        public static QrCode EncodeSegments(List<QrSegment> segs, Ecc ecl)
+        {
+            return EncodeSegments(segs, ecl, MinVersion, MaxVersion, -1, true);
+        }
+
+        /// <summary>
+        /// Returns a QR Code representing the specified segments with the specified encoding parameters.
+        /// </summary>
+        /// <remarks>
+        /// <para>The smallest possible QR Code version within the specified range is automatically
+        /// chosen for the output. Iff boostEcl is <c>true</c>, then the ECC level of the
+        /// result may be higher than the ecl argument if it can be done without increasing
+        /// the version. The mask number is either between 0 to 7 (inclusive) to force that
+        /// mask, or &#x2212;1 to automatically choose an appropriate mask (which may be slow).</para>
+        /// <para>This function allows the user to create a custom sequence of segments that switches
+        /// between modes (such as alphanumeric and byte) to encode text in less space.
+        /// This is a mid-level API; the high-level API is <see cref="EncodeText(string, Ecc)"/>
+        /// and <see cref="EncodeBinary(byte[], Ecc)"/>.</para>
+        /// </remarks>
+        /// <param name="segs">the segments to encode</param>
+        /// <param name="ecl">the error correction level to use (not <c>null</c>) (boostable)</param>
+        /// <param name="minVersion">the minimum allowed version of the QR Code (at least 1)</param>
+        /// <param name="maxVersion">the maximum allowed version of the QR Code (at most 40)</param>
+        /// <param name="mask">the mask number to use (between 0 and 7 (inclusive)), or &#x2212;1 for automatic mask</param>
+        /// <param name="boostEcl">increases the ECC level as long as it doesn't increase the version number</param>
+        /// <returns>a QR Code (not <c>null</c>) representing the segments</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the list of segments, any segment, or the error correction level is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if 1 &#x2264; minVersion &#x2264; maxVersion &#x2264; 40
+        /// or &#x2212;1 &#x2264; mask &#x2264; 7 is violated</exception>
+        /// <exception cref="DataTooLongException">Thrown DataTooLongException if the segments fail to fit in
+        /// the maxVersion QR Code at the ECL, which means they are too long</exception>
+        public static QrCode EncodeSegments(List<QrSegment> segs, Ecc ecl, int minVersion, int maxVersion, int mask, bool boostEcl)
+        {
+            Objects.RequireNonNull(segs);
+            Objects.RequireNonNull(ecl);
+            if (minVersion < MinVersion || minVersion > maxVersion)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minVersion), "Invalid value");
+            }
+            if (maxVersion > MaxVersion)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxVersion), "Invalid value");
+            }
+            if (mask < -1 || mask > 7)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mask), "Invalid value");
+            }
+
+            // Find the minimal version number to use
+            int version, dataUsedBits;
+            for (version = minVersion; ; version++)
+            {
+                int numDataBits = GetNumDataCodewords(version, ecl) * 8;  // Number of data bits available
+                dataUsedBits = QrSegment.GetTotalBits(segs, version);
+                if (dataUsedBits != -1 && dataUsedBits <= numDataBits)
+                {
+                    break;  // This version number is found to be suitable
+                }
+
+                if (version >= maxVersion)
+                {  // All versions in the range could not fit the given data
+                    string msg = "Segment too long";
+                    if (dataUsedBits != -1)
+                    {
+                        msg = $"Data length = {dataUsedBits} bits, Max capacity = {numDataBits} bits";
+                    }
+
+                    throw new DataTooLongException(msg);
+                }
+            }
+            Debug.Assert(dataUsedBits != -1);
+
+            // Increase the error correction level while the data still fits in the current version number
+            foreach (Ecc newEcl in Ecc.AllValues)
+            {  // From low to high
+                if (boostEcl && dataUsedBits <= GetNumDataCodewords(version, newEcl) * 8)
+                {
+                    ecl = newEcl;
+                }
+            }
+
+            // Concatenate all segments to create the data bit string
+            BitArray ba = new BitArray(0);
+            foreach (QrSegment seg in segs)
+            {
+                ba.AppendBits(seg.EncodingMode.ModeBits, 4);
+                ba.AppendBits((uint)seg.NumChars, seg.EncodingMode.NumCharCountBits(version));
+                ba.AppendData(seg.GetData());
+            }
+            Debug.Assert(ba.Length == dataUsedBits);
+
+            // Add terminator and pad up to a byte if applicable
+            int dataCapacityBits = GetNumDataCodewords(version, ecl) * 8;
+            Debug.Assert(ba.Length <= dataCapacityBits);
+            ba.AppendBits(0, Math.Min(4, dataCapacityBits - ba.Length));
+            ba.AppendBits(0, (8 - ba.Length % 8) % 8);
+            Debug.Assert(ba.Length % 8 == 0);
+
+            // Pad with alternating bytes until data capacity is reached
+            for (uint padByte = 0xEC; ba.Length < dataCapacityBits; padByte ^= 0xEC ^ 0x11)
+            {
+                ba.AppendBits(padByte, 8);
+            }
+
+            // Pack bits into bytes in big endian
+            byte[] dataCodewords = new byte[ba.Length / 8];
+            for (int i = 0; i < ba.Length; i++)
+            {
+                if (ba.Get(i))
+                {
+                    dataCodewords[i >> 3] |= (byte)(1 << (7 - (i & 7)));
+                }
+            }
+
+            // Create the QR Code object
+            return new QrCode(version, ecl, dataCodewords, mask);
+        }
+
+        #endregion
+
+
+        #region Public immutable properties
+
+        /// <summary>
+        /// The version number of this QR Code, which is between 1 and 40 (inclusive).
+        /// This determines the size of this barcode.
+        /// </summary>
+        public int Version { get; }
+
+        /// <summary>
+        /// The width and height of this QR Code, measured in modules, between
+        /// 21 and 177 (inclusive). This is equal to version &#xD7; 4 + 17.
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// The error correction level used in this QR Code, which is not <c>null</c>.
+        /// </summary>
+        public Ecc ErrorCorrectionLevel { get; }
+
+        /// <summary>
+        /// The index of the mask pattern used in this QR Code, which is between 0 and 7 (inclusive).
+        /// </summary>
+        /// <remarks>Even if a QR Code is created with automatic masking requested (mask =
+        /// &#x2212;1), the resulting object still has a mask value between 0 and 7.
+        /// </remarks>
+        public int Mask { get; }
+
+        #endregion
+
+
+        #region Private grids of modules/pixels, with dimensions of size * size
+
+        // The modules of this QR Code (false = white, true = black).
+        // Immutable after constructor finishes. Accessed through getModule().
+        private readonly bool[,] _modules;
+
+        // Indicates function modules that are not subjected to masking. Discarded when constructor finishes.
+        private readonly bool[,] _isFunction;
+
+        #endregion
+
+
+        #region  Constructor (low level)
+
+        /// <summary>
+        /// Constructs a QR Code with the specified version number,
+        /// error correction level, data codeword bytes, and mask number.
+        /// </summary>
+        /// <remarks>
+        /// This is a low-level API that most users should not use directly. A mid-level
+        /// API is the <see cref="EncodeSegments(List{QrSegment}, Ecc, int, int, int, bool)"/> function.
+        /// </remarks>
+        /// <param name="ver">the version number to use, which must be in the range 1 to 40 (inclusive)</param>
+        /// <param name="ecl">the error correction level to use</param>
+        /// <param name="dataCodewords">the bytes representing segments to encode (without ECC)</param>
+        /// <param name="mask">the mask pattern to use, which is either &#x2212;1 for automatic choice or from 0 to 7 for fixed choice</param>
+        /// <exception cref="ArgumentNullException">Thrown if the byte array or error correction level is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the version or mask value is out of range,
+        /// or if the data is the wrong length for the specified version and error correction level</exception>
+        public QrCode(int ver, Ecc ecl, byte[] dataCodewords, int mask)
+        {
+            // Check arguments and initialize fields
+            if (ver < MinVersion || ver > MaxVersion)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ver), "Version value out of range");
+            }
+
+            if (mask < -1 || mask > 7)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mask), "Mask value out of range");
+            }
+
+            Version = ver;
+            Size = ver * 4 + 17;
+            Objects.RequireNonNull(ecl);
+            ErrorCorrectionLevel = ecl;
+            Objects.RequireNonNull(dataCodewords);
+            _modules = new bool[Size, Size];  // Initially all white
+            _isFunction = new bool[Size, Size];
+
+            // Compute ECC, draw modules, do masking
+            DrawFunctionPatterns();
+            byte[] allCodewords = AddEccAndInterleave(dataCodewords);
+            DrawCodewords(allCodewords);
+            Mask = HandleConstructorMasking(mask);
+            _isFunction = null;
+        }
+
+
+        #endregion
+
+
+        #region Public methods
+
+        /// <summary>
+        /// Returns the color of the module (pixel) at the specified coordinates, which is <c>false</c>
+        /// for white or <c>true</c> for black.
+        /// </summary>
+        /// <remarks>
+        /// The top left corner has the coordinates (x=0, y=0).
+        /// If the specified coordinates are out of bounds, then <c>false</c>
+        /// (white) is returned.
+        /// </remarks>
+        /// <param name="x">the x coordinate, where 0 is the left edge and size&#x2212;1 is the right edge</param>
+        /// <param name="y">the y coordinate, where 0 is the top edge and size&#x2212;1 is the bottom edge</param>
+        /// <returns><c>true</c> if the coordinates are in bounds and the module
+        /// at that location is black, or <c>false</c> (white) otherwise</returns>
+        public bool GetModule(int x, int y)
+        {
+            return 0 <= x && x < Size && 0 <= y && y < Size && _modules[y, x];
+        }
+
+        #endregion
+
+
+        #region Private helper methods for constructor: Drawing function modules
+
+        // Reads this object's version field, and draws and marks all function modules.
+        private void DrawFunctionPatterns()
+        {
+            // Draw horizontal and vertical timing patterns
+            for (int i = 0; i < Size; i++)
+            {
+                SetFunctionModule(6, i, i % 2 == 0);
+                SetFunctionModule(i, 6, i % 2 == 0);
+            }
+
+            // Draw 3 finder patterns (all corners except bottom right; overwrites some timing modules)
+            DrawFinderPattern(3, 3);
+            DrawFinderPattern(Size - 4, 3);
+            DrawFinderPattern(3, Size - 4);
+
+            // Draw numerous alignment patterns
+            int[] alignPatPos = GetAlignmentPatternPositions();
+            int numAlign = alignPatPos.Length;
+            for (int i = 0; i < numAlign; i++)
+            {
+                for (int j = 0; j < numAlign; j++)
+                {
+                    // Don't draw on the three finder corners
+                    if (!(i == 0 && j == 0 || i == 0 && j == numAlign - 1 || i == numAlign - 1 && j == 0))
+                    {
+                        DrawAlignmentPattern(alignPatPos[i], alignPatPos[j]);
+                    }
+                }
+            }
+
+            // Draw configuration data
+            DrawFormatBits(0);  // Dummy mask value; overwritten later in the constructor
+            DrawVersion();
+        }
+
+
+        // Draws two copies of the format bits (with its own error correction code)
+        // based on the given mask and this object's error correction level field.
+        private void DrawFormatBits(uint mask)
+        {
+            // Calculate error correction code and pack bits
+            uint data = (ErrorCorrectionLevel.FormatBits << 3) | mask;  // errCorrLvl is uint2, mask is uint3
+            uint rem = data;
+            for (int i = 0; i < 10; i++)
+            {
+                rem = (rem << 1) ^ ((rem >> 9) * 0x537);
+            }
+
+            uint bits = ((data << 10) | rem) ^ 0x5412;  // uint15
+            Debug.Assert(bits >> 15 == 0);
+
+            // Draw first copy
+            for (int i = 0; i <= 5; i++)
+            {
+                SetFunctionModule(8, i, GetBit(bits, i));
+            }
+
+            SetFunctionModule(8, 7, GetBit(bits, 6));
+            SetFunctionModule(8, 8, GetBit(bits, 7));
+            SetFunctionModule(7, 8, GetBit(bits, 8));
+            for (int i = 9; i < 15; i++)
+            {
+                SetFunctionModule(14 - i, 8, GetBit(bits, i));
+            }
+
+            // Draw second copy
+            for (int i = 0; i < 8; i++)
+            {
+                SetFunctionModule(Size - 1 - i, 8, GetBit(bits, i));
+            }
+
+            for (int i = 8; i < 15; i++)
+            {
+                SetFunctionModule(8, Size - 15 + i, GetBit(bits, i));
+            }
+
+            SetFunctionModule(8, Size - 8, true);  // Always black
+        }
+
+
+        // Draws two copies of the version bits (with its own error correction code),
+        // based on this object's version field, iff 7 <= version <= 40.
+        private void DrawVersion()
+        {
+            if (Version < 7)
+            {
+                return;
+            }
+
+            // Calculate error correction code and pack bits
+            uint rem = (uint)Version;  // version is uint6, in the range [7, 40]
+            for (int i = 0; i < 12; i++)
+            {
+                rem = (rem << 1) ^ ((rem >> 11) * 0x1F25);
+            }
+
+            uint bits = ((uint)Version << 12) | rem;  // uint18
+            Debug.Assert(bits >> 18 == 0);
+
+            // Draw two copies
+            for (int i = 0; i < 18; i++)
+            {
+                bool bit = GetBit(bits, i);
+                int a = Size - 11 + i % 3;
+                int b = i / 3;
+                SetFunctionModule(a, b, bit);
+                SetFunctionModule(b, a, bit);
+            }
+        }
+
+        // Draws a 9*9 finder pattern including the border separator,
+        // with the center module at (x, y). Modules can be out of bounds.
+        private void DrawFinderPattern(int x, int y)
+        {
+            for (int dy = -4; dy <= 4; dy++)
+            {
+                for (int dx = -4; dx <= 4; dx++)
+                {
+                    int dist = Math.Max(Math.Abs(dx), Math.Abs(dy));  // Chebyshev/infinity norm
+                    int xx = x + dx, yy = y + dy;
+                    if (0 <= xx && xx < Size && 0 <= yy && yy < Size)
+                    {
+                        SetFunctionModule(xx, yy, dist != 2 && dist != 4);
+                    }
+                }
+            }
+        }
+
+
+        // Draws a 5*5 alignment pattern, with the center module
+        // at (x, y). All modules must be in bounds.
+        private void DrawAlignmentPattern(int x, int y)
+        {
+            for (int dy = -2; dy <= 2; dy++)
+            {
+                for (int dx = -2; dx <= 2; dx++)
+                {
+                    SetFunctionModule(x + dx, y + dy, Math.Max(Math.Abs(dx), Math.Abs(dy)) != 1);
+                }
+            }
+        }
+
+
+        // Sets the color of a module and marks it as a function module.
+        // Only used by the constructor. Coordinates must be in bounds.
+        private void SetFunctionModule(int x, int y, bool isBlack)
+        {
+            _modules[y, x] = isBlack;
+            _isFunction[y, x] = true;
+        }
+
+        #endregion
+
+
+        #region Private helper methods for constructor: Codewords and masking
+
+        // Returns a new byte string representing the given data with the appropriate error correction
+        // codewords appended to it, based on this object's version and error correction level.
+        private byte[] AddEccAndInterleave(byte[] data)
+        {
+            Objects.RequireNonNull(data);
+            if (data.Length != GetNumDataCodewords(Version, ErrorCorrectionLevel))
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            // Calculate parameter numbers
+            int numBlocks = NumErrorCorrectionBlocks[ErrorCorrectionLevel.Ordinal, Version];
+            int blockEccLen = EccCodewordsPerBlock[ErrorCorrectionLevel.Ordinal, Version];
+            int rawCodewords = GetNumRawDataModules(Version) / 8;
+            int numShortBlocks = numBlocks - rawCodewords % numBlocks;
+            int shortBlockLen = rawCodewords / numBlocks;
+
+            // Split data into blocks and append ECC to each block
+            byte[][] blocks = new byte[numBlocks][];
+            ReedSolomonGenerator rs = new ReedSolomonGenerator(blockEccLen);
+            for (int i = 0, k = 0; i < numBlocks; i++)
+            {
+                byte[] dat = CopyOfRange(data, k, k + shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1));
+                k += dat.Length;
+                byte[] block = CopyOf(dat, shortBlockLen + 1);
+                byte[] ecc = rs.GetRemainder(dat);
+                Array.Copy(ecc, 0, block, block.Length - blockEccLen, ecc.Length);
+                blocks[i] = block;
+            }
+
+            // Interleave (not concatenate) the bytes from every block into a single sequence
+            byte[] result = new byte[rawCodewords];
+            for (int i = 0, k = 0; i < blocks[0].Length; i++)
+            {
+                for (int j = 0; j < blocks.Length; j++)
+                {
+                    // Skip the padding byte in short blocks
+                    if (i != shortBlockLen - blockEccLen || j >= numShortBlocks)
+                    {
+                        result[k] = blocks[j][i];
+                        k++;
+                    }
+                }
+            }
+            return result;
+        }
+
+
+        // Draws the given sequence of 8-bit codewords (data and error correction) onto the entire
+        // data area of this QR Code. Function modules need to be marked off before this is called.
+        private void DrawCodewords(byte[] data)
+        {
+            Objects.RequireNonNull(data);
+            if (data.Length != GetNumRawDataModules(Version) / 8)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            int i = 0;  // Bit index into the data
+                        // Do the funny zigzag scan
+            for (int right = Size - 1; right >= 1; right -= 2)
+            {
+                // Index of right column in each column pair
+                if (right == 6)
+                {
+                    right = 5;
+                }
+
+                for (int vert = 0; vert < Size; vert++)
+                {
+                    // Vertical counter
+                    for (int j = 0; j < 2; j++)
+                    {
+                        int x = right - j;  // Actual x coordinate
+                        bool upward = ((right + 1) & 2) == 0;
+                        int y = upward ? Size - 1 - vert : vert;  // Actual y coordinate
+                        if (!_isFunction[y, x] && i < data.Length * 8)
+                        {
+                            _modules[y, x] = GetBit(data[((uint)i) >> 3], 7 - (i & 7));
+                            i++;
+                        }
+                        // If this QR Code has any remainder bits (0 to 7), they were assigned as
+                        // 0/false/white by the constructor and are left unchanged by this method
+                    }
+                }
+            }
+            Debug.Assert(i == data.Length * 8);
+        }
+
+
+        // XORs the codeword modules in this QR Code with the given mask pattern.
+        // The function modules must be marked and the codeword bits must be drawn
+        // before masking. Due to the arithmetic of XOR, calling applyMask() with
+        // the same mask value a second time will undo the mask. A final well-formed
+        // QR Code needs exactly one (not zero, two, etc.) mask applied.
+        private void ApplyMask(uint mask)
+        {
+            if (mask > 7)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mask), "Mask value out of range");
+            }
+
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+                {
+                    bool invert;
+                    switch (mask)
+                    {
+                        case 0: invert = (x + y) % 2 == 0; break;
+                        case 1: invert = y % 2 == 0; break;
+                        case 2: invert = x % 3 == 0; break;
+                        case 3: invert = (x + y) % 3 == 0; break;
+                        case 4: invert = (x / 3 + y / 2) % 2 == 0; break;
+                        case 5: invert = x * y % 2 + x * y % 3 == 0; break;
+                        case 6: invert = (x * y % 2 + x * y % 3) % 2 == 0; break;
+                        case 7: invert = ((x + y) % 2 + x * y % 3) % 2 == 0; break;
+                        default: Debug.Assert(false); return;
+                    }
+                    _modules[y, x] ^= invert & !_isFunction[y, x];
+                }
+            }
+        }
+
+
+        // A messy helper function for the constructor. This QR Code must be in an unmasked state when this
+        // method is called. The given argument is the requested mask, which is -1 for auto or 0 to 7 for fixed.
+        // This method applies and returns the actual mask chosen, from 0 to 7.
+        private int HandleConstructorMasking(int mask)
+        {
+            if (mask == -1)
+            {
+                // Automatically choose best mask
+                int minPenalty = int.MaxValue;
+                for (uint i = 0; i < 8; i++)
+                {
+                    ApplyMask(i);
+                    DrawFormatBits(i);
+                    int penalty = GetPenaltyScore();
+                    if (penalty < minPenalty)
+                    {
+                        mask = (int)i;
+                        minPenalty = penalty;
+                    }
+                    ApplyMask(i);  // Undoes the mask due to XOR
+                }
+            }
+            Debug.Assert(0 <= mask && mask <= 7);
+            ApplyMask((uint)mask);  // Apply the final choice of mask
+            DrawFormatBits((uint)mask);  // Overwrite old format bits
+            return mask;  // The caller shall assign this value to the final-declared field
+        }
+
+
+        // Calculates and returns the penalty score based on state of this QR Code's current modules.
+        // This is used by the automatic mask choice algorithm to find the mask pattern that yields the lowest score.
+        private int GetPenaltyScore()
+        {
+            int result = 0;
+
+            // Adjacent modules in row having same color, and finder-like patterns
+            for (int y = 0; y < Size; y++)
+            {
+                int[] runHistory = new int[7];
+                bool color = false;
+                int runX = 0;
+                for (int x = 0; x < Size; x++)
+                {
+                    if (_modules[y, x] == color)
+                    {
+                        runX++;
+                        if (runX == 5)
+                        {
+                            result += PenaltyN1;
+                        }
+                        else if (runX > 5)
+                        {
+                            result++;
+                        }
+                    }
+                    else
+                    {
+                        AddRunToHistory(runX, runHistory);
+                        if (!color && HasFinderLikePattern(runHistory))
+                        {
+                            result += PenaltyN3;
+                        }
+
+                        color = _modules[y, x];
+                        runX = 1;
+                    }
+                }
+                AddRunToHistory(runX, runHistory);
+                if (color)
+                {
+                    AddRunToHistory(0, runHistory);  // Dummy run of white
+                }
+
+                if (HasFinderLikePattern(runHistory))
+                {
+                    result += PenaltyN3;
+                }
+            }
+            // Adjacent modules in column having same color, and finder-like patterns
+            for (int x = 0; x < Size; x++)
+            {
+                int[] runHistory = new int[7];
+                bool color = false;
+                int runY = 0;
+                for (int y = 0; y < Size; y++)
+                {
+                    if (_modules[y, x] == color)
+                    {
+                        runY++;
+                        if (runY == 5)
+                        {
+                            result += PenaltyN1;
+                        }
+                        else if (runY > 5)
+                        {
+                            result++;
+                        }
+                    }
+                    else
+                    {
+                        AddRunToHistory(runY, runHistory);
+                        if (!color && HasFinderLikePattern(runHistory))
+                        {
+                            result += PenaltyN3;
+                        }
+
+                        color = _modules[y, x];
+                        runY = 1;
+                    }
+                }
+                AddRunToHistory(runY, runHistory);
+                if (color)
+                {
+                    AddRunToHistory(0, runHistory);  // Dummy run of white
+                }
+
+                if (HasFinderLikePattern(runHistory))
+                {
+                    result += PenaltyN3;
+                }
+            }
+
+            // 2*2 blocks of modules having same color
+            for (int y = 0; y < Size - 1; y++)
+            {
+                for (int x = 0; x < Size - 1; x++)
+                {
+                    bool color = _modules[y, x];
+                    if (color == _modules[y, x + 1] &&
+                          color == _modules[y + 1, x] &&
+                          color == _modules[y + 1, x + 1])
+                    {
+                        result += PenaltyN2;
+                    }
+                }
+            }
+
+            // Balance of black and white modules
+            int black = 0;
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+
+                {
+                    if (_modules[y, x])
+                    {
+                        black++;
+                    }
+                }
+            }
+            int total = Size * Size;  // Note that size is odd, so black/total != 1/2
+                                      // Compute the smallest integer k >= 0 such that (45-5k)% <= black/total <= (55+5k)%
+            int k = (Math.Abs(black * 20 - total * 10) + total - 1) / total - 1;
+            result += k * PenaltyN4;
+            return result;
+        }
+
+
+        #endregion
+
+
+        #region Private helper functions
+
+        // Returns an ascending list of positions of alignment patterns for this version number.
+        // Each position is in the range [0,177), and are used on both the x and y axes.
+        // This could be implemented as lookup table of 40 variable-length lists of unsigned bytes.
+        private int[] GetAlignmentPatternPositions()
+        {
+            if (Version == 1)
+            {
+                return new int[] { };
+            }
+            else
+            {
+                int numAlign = Version / 7 + 2;
+                int step;
+                if (Version == 32)  // Special snowflake
+                {
+                    step = 26;
+                }
+                else  // step = ceil[(size - 13) / (numAlign*2 - 2)] * 2
+                {
+                    step = (Version * 4 + numAlign * 2 + 1) / (numAlign * 2 - 2) * 2;
+                }
+
+                int[] result = new int[numAlign];
+                result[0] = 6;
+                for (int i = result.Length - 1, pos = Size - 7; i >= 1; i--, pos -= step)
+                {
+                    result[i] = pos;
+                }
+
+                return result;
+            }
+        }
+
+        // Returns the number of data bits that can be stored in a QR Code of the given version number, after
+        // all function modules are excluded. This includes remainder bits, so it might not be a multiple of 8.
+        // The result is in the range [208, 29648]. This could be implemented as a 40-entry lookup table.
+        private static int GetNumRawDataModules(int ver)
+        {
+            if (ver < MinVersion || ver > MaxVersion)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ver), "Version number out of range");
+            }
+
+            int size = ver * 4 + 17;
+            int result = size * size;   // Number of modules in the whole QR Code square
+            result -= 8 * 8 * 3;        // Subtract the three finders with separators
+            result -= 15 * 2 + 1;       // Subtract the format information and black module
+            result -= (size - 16) * 2;  // Subtract the timing patterns (excluding finders)
+                                        // The five lines above are equivalent to: int result = (16 * ver + 128) * ver + 64;
+            if (ver >= 2)
+            {
+                int numAlign = ver / 7 + 2;
+                result -= (numAlign - 1) * (numAlign - 1) * 25;  // Subtract alignment patterns not overlapping with timing patterns
+                result -= (numAlign - 2) * 2 * 20;  // Subtract alignment patterns that overlap with timing patterns
+                                                    // The two lines above are equivalent to: result -= (25 * numAlign - 10) * numAlign - 55;
+                if (ver >= 7)
+                {
+                    result -= 6 * 3 * 2;  // Subtract version information
+                }
+            }
+            return result;
+        }
+
+
+        // Returns the number of 8-bit data (i.e. not error correction) codewords contained in any
+        // QR Code of the given version number and error correction level, with remainder bits discarded.
+        // This stateless pure function could be implemented as a (40*4)-cell lookup table.
+        private static int GetNumDataCodewords(int ver, Ecc ecl)
+        {
+            return GetNumRawDataModules(ver) / 8
+                - EccCodewordsPerBlock[ecl.Ordinal, ver]
+                * NumErrorCorrectionBlocks[ecl.Ordinal, ver];
+        }
+
+
+        // Inserts the given value to the front of the given array, which shifts over the
+        // existing values and deletes the last value. A helper function for GetPenaltyScore().
+        private static void AddRunToHistory(int run, int[] history)
+        {
+            Array.Copy(history, 0, history, 1, history.Length - 1);
+            history[0] = run;
+        }
+
+
+        // Tests whether the given run history has the pattern of ratio 1:1:3:1:1 in the middle, and
+        // surrounded by at least 4 on either or both ends. A helper function for GetPenaltyScore().
+        // Must only be called immediately after a run of white modules has ended.
+        private static bool HasFinderLikePattern(int[] runHistory)
+        {
+            int n = runHistory[1];
+            return n > 0 && runHistory[2] == n && runHistory[4] == n && runHistory[5] == n
+                && runHistory[3] == n * 3 && Math.Max(runHistory[0], runHistory[6]) >= n * 4;
+        }
+
+
+        private static byte[] CopyOfRange(byte[] original, int from, int to)
+        {
+            byte[] result = new byte[to - from];
+            Array.Copy(original, from, result, 0, to - from);
+            return result;
+        }
+
+
+        private static byte[] CopyOf(byte[] original, int newLength)
+        {
+            byte[] result = new byte[newLength];
+            Array.Copy(original, result, Math.Min(original.Length, newLength));
+            return result;
+        }
+
+
+        // Returns true iff the i'th bit of x is set to 1.
+        private static bool GetBit(uint x, int i)
+        {
+            return ((x >> i) & 1) != 0;
+        }
+
+        #endregion
+
+
+        #region Constants and tables
+
+        /// <summary>
+        /// The minimum version number  (1) supported in the QR Code Model 2 standard.
+        /// </summary>
+        public static readonly int MinVersion = 1;
+
+        /// <summary>
+        /// The maximum version number (40) supported in the QR Code Model 2 standard.
+        /// </summary>
+        public static readonly int MaxVersion = 40;
+
+
+        // For use in getPenaltyScore(), when evaluating which mask is best.
+        private static readonly int PenaltyN1 = 3;
+        private static readonly int PenaltyN2 = 3;
+        private static readonly int PenaltyN3 = 40;
+        private static readonly int PenaltyN4 = 10;
+
+
+        private static readonly byte[,] EccCodewordsPerBlock = {
+		    // Version: (note that index 0 is for padding, and is set to an illegal value)
+		    //  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40     Error correction level
+		    { 255,  7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },  // Low
+		    { 255, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28 },  // Medium
+		    { 255, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },  // Quartile
+		    { 255, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30 },  // High
+	    };
+
+        private static readonly byte[,] NumErrorCorrectionBlocks = {
+		    // Version: (note that index 0 is for padding, and is set to an illegal value)
+		    //  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40     Error correction level
+		    { 255, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25 },  // Low
+		    { 255, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49 },  // Medium
+		    { 255, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68 },  // Quartile
+		    { 255, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81 },  // High
+	    };
+
+        #endregion
+
+
+        #region Public helper enumeration
+
+        /// <summary>
+        /// The error correction level in a QR Code symbol.
+        /// </summary>
+        public sealed class Ecc
+        {
+            /// <summary>
+            /// The QR Code can tolerate about 7% erroneous codewords.
+            /// </summary>
+            public static readonly Ecc Low = new Ecc(0, 1);
+
+            /// <summary>
+            /// The QR Code can tolerate about 15% erroneous codewords.
+            /// </summary>
+            public static readonly Ecc Medium = new Ecc(1, 0);
+
+            /// <summary>
+            /// The QR Code can tolerate about 25% erroneous codewords.
+            /// </summary>
+            public static readonly Ecc Quartile = new Ecc(2, 3);
+
+            /// <summary>
+            /// The QR Code can tolerate about 30% erroneous codewords.
+            /// </summary>
+            public static readonly Ecc High = new Ecc(3, 2);
+
+
+            internal static Ecc[] AllValues = { Low, Medium, Quartile, High };
+
+            /// <summary>
+            /// Ordinal number of error correction level (in the range 0 to 3).
+            /// </summary>
+            /// <remarks>
+            /// Higher number represent a higher amount of error tolerance.
+            /// </remarks>
+            public int Ordinal { get; }
+
+            // In the range 0 to 3 (unsigned 2-bit integer).
+            internal uint FormatBits { get; }
+
+            // Constructor.
+            private Ecc(int ordinal, uint fb)
+            {
+                Ordinal = ordinal;
+                FormatBits = fb;
+            }
+        }
+
+
+        #endregion
+    }
+}

--- a/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Io.Nayuki.QrCodeGen</RootNamespace>
-    <PackageId>Io.Nayuki.QrCodeGen</PackageId>
+    <RootNamespace>IO.Nayuki.QrCodeGen</RootNamespace>
+    <PackageId>IO.Nayuki.QrCodeGen</PackageId>
     <Version>1.4.1</Version>
     <Authors>Project Nayuki</Authors>
     <Product>QR Code Generator for .NET</Product>

--- a/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
@@ -16,4 +16,8 @@
     <PackageReleaseNotes>Initial release for .NET</PackageReleaseNotes>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
+++ b/dotnet/QrCodeGenerator/QrCodeGenerator.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Io.Nayuki.QrCodeGen</RootNamespace>
+    <PackageId>Io.Nayuki.QrCodeGen</PackageId>
+    <Version>1.4.1</Version>
+    <Authors>Project Nayuki</Authors>
+    <Product>QR Code Generator for .NET</Product>
+    <Description>This project aims to be the best, clearest QR Code generator library in multiple languages. The primary goals are flexible options and absolute correctness. Secondary goals are compact implementation size and good documentation comments</Description>
+    <Copyright>Copyright (c) Project Nayuki. (MIT License)</Copyright>
+    <RepositoryUrl>https://github.com/nayuki/QR-Code-generator</RepositoryUrl>
+    <PackageProjectUrl>https://www.nayuki.io/page/qr-code-generator-library</PackageProjectUrl>
+    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageTags>qr code, qrcode</PackageTags>
+    <PackageReleaseNotes>Initial release for .NET</PackageReleaseNotes>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/QrCodeGenerator/QrSegment.cs
+++ b/dotnet/QrCodeGenerator/QrSegment.cs
@@ -1,0 +1,379 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// A segment of character/binary/control data in a QR Code symbol.
+    /// </summary>
+    /// <remarks>
+    /// <para>Instances of this class are immutable.</para>
+    /// <para>The mid-level way to create a segment is to take the payload data and call a
+    /// static factory function such as <see cref="MakeNumeric(string)"/>. The low-level
+    /// way to create a segment is to custom-make the bit buffer and call the
+    /// <see cref="QrSegment(Mode, int, BitArray)"/> with appropriate values.</para>
+    /// <para>This segment class imposes no length restrictions, but QR Codes have restrictions.
+    /// Even in the most favorable conditions, a QR Code can only hold 7089 characters of data.
+    /// Any segment longer than this is meaningless for the purpose of generating QR Codes.
+    /// This class can represent kanji mode segments, but provides no help in encoding them
+    /// - see <see cref="QrSegmentAdvanced"/> for full kanji support.</para>
+    /// </remarks>
+    public class QrSegment
+    {
+        #region Static factory functions (mid level)
+
+        /// <summary>
+        /// Returns a segment representing the specified binary data
+        /// encoded in byte mode. All input byte arrays are acceptable.
+        /// </summary>
+        /// <remarks>
+        /// Any text string can be converted to UTF-8 bytes (<c>Encoding.UTF8.GetBytes(s)</c>)
+        /// and encoded as a byte mode segment.
+        /// </remarks>
+        /// <param name="data">the binary data (not <c>null</c>)</param>
+        /// <returns>a segment (not <c>null</c>) containing the data</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the array is <c>null</c></exception>
+        public static QrSegment MakeBytes(byte[] data)
+        {
+            Objects.RequireNonNull(data);
+            BitArray ba = new BitArray(0);
+            foreach (byte b in data)
+            {
+                ba.AppendBits(b, 8);
+            }
+
+            return new QrSegment(Mode.Byte, data.Length, ba);
+        }
+
+
+        /// <summary>
+        /// Returns a segment representing the specified string of decimal digits encoded in numeric mode.
+        /// </summary>
+        /// <param name="digits">the text (not <c>null</c>), with only digits from 0 to 9 allowed</param>
+        /// <returns>a segment (not <c>null</c>) containing the text</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the string is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the string contains non-digit characters</exception>
+        public static QrSegment MakeNumeric(string digits)
+        {
+            Objects.RequireNonNull(digits);
+            if (!NumericRegex.IsMatch(digits))
+            {
+                throw new ArgumentOutOfRangeException(nameof(digits), "String contains non-numeric characters");
+            }
+
+            BitArray ba = new BitArray(0);
+            for (int i = 0; i < digits.Length;)
+            {
+                // Consume up to 3 digits per iteration
+                int n = Math.Min(digits.Length - i, 3);
+                ba.AppendBits(uint.Parse(digits.Substring(i, n)), n * 3 + 1);
+                i += n;
+            }
+            return new QrSegment(Mode.Numeric, digits.Length, ba);
+        }
+
+
+        /// <summary>
+        /// Returns a segment representing the specified text string encoded in alphanumeric mode.
+        /// The characters allowed are: 0 to 9, A to Z(uppercase only), space,
+        /// dollar, percent, asterisk, plus, hyphen, period, slash, colon.
+        /// </summary>
+        /// <param name="text">the text (not <c>null</c>), with only certain characters allowed</param>
+        /// <returns>a segment (not <c>null</c>) containing the text</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the string is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown iif the string contains non-encodable characters</exception>
+        public static QrSegment MakeAlphanumeric(string text)
+        {
+            Objects.RequireNonNull(text);
+            if (!AlphanumericRegex.IsMatch(text))
+            {
+                throw new ArgumentOutOfRangeException(nameof(text), "String contains unencodable characters in alphanumeric mode");
+            }
+
+            BitArray ba = new BitArray(0);
+            int i;
+            for (i = 0; i <= text.Length - 2; i += 2)
+            {
+                // Process groups of 2
+                uint temp = (uint)AlphanumericCharset.IndexOf(text[i]) * 45;
+                temp += (uint)AlphanumericCharset.IndexOf(text[i + 1]);
+                ba.AppendBits(temp, 11);
+            }
+            if (i < text.Length)  // 1 character remaining
+            {
+                ba.AppendBits((uint)AlphanumericCharset.IndexOf(text[i]), 6);
+            }
+
+            return new QrSegment(Mode.Alphanumeric, text.Length, ba);
+        }
+
+
+        /// <summary>
+        /// Returns a list of zero or more segments to represent the specified Unicode text string.
+        /// The result may use various segment modes and switch modes to optimize the length of the bit stream.
+        /// </summary>
+        /// <param name="text">the text to be encoded, which can be any Unicode string</param>
+        /// <returns>a new mutable list (not <c>null</c>) of segments (not <c>null</c>) containing the text</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the text is <c>null</c></exception>
+        public static List<QrSegment> MakeSegments(string text)
+        {
+            Objects.RequireNonNull(text);
+
+            // Select the most efficient segment encoding automatically
+            List<QrSegment> result = new List<QrSegment>();
+            if (text == "")
+            {
+                // Leave result empty
+            }
+            else if (NumericRegex.IsMatch(text))
+            {
+                result.Add(MakeNumeric(text));
+            }
+            else if (AlphanumericRegex.IsMatch(text))
+            {
+                result.Add(MakeAlphanumeric(text));
+            }
+            else
+            {
+                result.Add(MakeBytes(Encoding.UTF8.GetBytes(text)));
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Returns a segment representing an Extended Channel Interpretation
+        /// (ECI) designator with the specified assignment value.
+        /// </summary>
+        /// <param name="assignVal">the ECI assignment number (see the AIM ECI specification)</param>
+        /// <returns>a segment (not <c>null</c>) containing the data</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the value is outside the range [0, 10<sup>6</sup>)</exception>
+        public static QrSegment MakeEci(int assignVal)
+        {
+            BitArray ba = new BitArray(0);
+            if (assignVal < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(assignVal), "ECI assignment value out of range");
+            }
+
+            if (assignVal < (1 << 7))
+            {
+                ba.AppendBits((uint)assignVal, 8);
+            }
+            else if (assignVal < (1 << 14))
+            {
+                ba.AppendBits(2, 2);
+                ba.AppendBits((uint)assignVal, 14);
+            }
+            else if (assignVal < 1_000_000)
+            {
+                ba.AppendBits(6, 3);
+                ba.AppendBits((uint)assignVal, 21);
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(assignVal), "ECI assignment value out of range");
+            }
+
+            return new QrSegment(Mode.Eci, 0, ba);
+        }
+
+        #endregion
+
+
+        #region Instance fields
+
+        /// <summary>
+        /// The mode indicator of this segment. Not <c>null</c>.
+        /// </summary>
+        public Mode EncodingMode { get; }
+
+        /// <summary>
+        /// The length of this segment's unencoded data. Measured in characters for
+        /// numeric/alphanumeric/kanji mode, bytes for byte mode, and 0 for ECI mode.
+        /// Always zero or positive. Not the same as the data's bit length.
+        /// </summary>
+        public int NumChars { get; }
+
+        // The data bits of this segment. Not null. Accessed through GetData().
+        private readonly BitArray _data;
+
+        #endregion
+
+
+        #region Constructor (low level)
+
+        /// <summary>
+        /// Constructs a QR Code segment with the specified attributes and data.
+        /// The character count(numCh) must agree with the mode and the bit buffer length,
+        /// but the constraint isn't checked. The specified bit buffer is cloned and stored.
+        /// </summary>
+        /// <param name="md">the mode (not <c>null</c>)</param>
+        /// <param name="numCh">the data length in characters or bytes, which is non-negative</param>
+        /// <param name="data">the data bits (not <c>null</c>)</param>
+        /// <exception cref="ArgumentNullException">Thrown if the mode or data is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the character count is negative</exception>
+        public QrSegment(Mode md, int numCh, BitArray data)
+        {
+            EncodingMode = Objects.RequireNonNull(md);
+            Objects.RequireNonNull(data);
+            if (numCh < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(numCh), "Invalid value");
+            }
+
+            NumChars = numCh;
+            _data = (BitArray)data.Clone();  // Make defensive copy
+        }
+
+        #endregion
+
+
+        #region Methods
+
+        /// <summary>
+        /// Returns the data bits of this segment.
+        /// </summary>
+        /// <returns>a new copy of the data bits(not<c>null</c>)</returns>
+        public BitArray GetData()
+        {
+            return (BitArray)_data.Clone();  // Make defensive copy
+        }
+
+
+        // Calculates the number of bits needed to encode the given segments at the given version.
+        // Returns a non-negative number if successful. Otherwise returns -1 if a segment has too
+        // many characters to fit its length field, or the total bits exceeds int.MaxValue.
+        internal static int GetTotalBits(List<QrSegment> segs, int version)
+        {
+            Objects.RequireNonNull(segs);
+            long result = 0;
+            foreach (QrSegment seg in segs)
+            {
+                Objects.RequireNonNull(seg);
+                int ccbits = seg.EncodingMode.NumCharCountBits(version);
+                if (seg.NumChars >= (1 << ccbits))
+                {
+                    return -1;  // The segment's length doesn't fit the field's bit width
+                }
+
+                result += 4L + ccbits + seg._data.Length;
+                if (result > int.MaxValue)
+                {
+                    return -1;  // The sum will overflow an int type
+                }
+            }
+            return (int)result;
+        }
+
+        #endregion
+
+
+        #region Constants
+
+        /// <summary>
+        /// Describes precisely all strings that are encodable in numeric mode.
+        /// </summary>
+        /// <remarks>
+        /// To test whether a string <c>s</c> is encodable:
+        /// <code>
+        /// bool ok = NumericRegex.IsMatch(s);
+        /// </code> 
+        /// A string is encodable iff each character is in the range 0 to 9.
+        /// </remarks>
+        /// <seealso cref="MakeNumeric(string)"/>
+        public static readonly Regex NumericRegex = new Regex("^[0-9]*$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Describes precisely all strings that are encodable in alphanumeric mode.
+        /// </summary>
+        /// <remarks>
+        /// To test whether a string <c>s</c> is encodable:
+        /// <code>
+        /// bool ok = AlphanumericRegex.IsMatch(s);
+        /// </code> 
+        /// A string is encodable iff each character is in the following set: 0 to 9, A to Z
+        /// (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
+        /// </remarks>
+        /// <seealso cref="MakeAlphanumeric(string)"/>
+        public static readonly Regex AlphanumericRegex = new Regex("^[A-Z0-9 $%*+./:-]*$", RegexOptions.Compiled);
+
+
+        // The set of all legal characters in alphanumeric mode, where
+        // each character value maps to the index in the string.
+        static readonly string AlphanumericCharset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+        #endregion
+
+
+        #region Public helper enumeration
+
+        /// <summary>
+        /// Describes how a segment's data bits are interpreted.
+        /// </summary>
+        public sealed class Mode
+        {
+            public static readonly Mode Numeric = new Mode(0x1, 10, 12, 14);
+
+            public static readonly Mode Alphanumeric = new Mode(0x2, 9, 11, 13);
+
+            public static readonly Mode Byte = new Mode(0x4, 8, 16, 16);
+
+            public static readonly Mode Kanji = new Mode(0x8, 8, 10, 12);
+
+            public static readonly Mode Eci = new Mode(0x7, 0, 0, 0);
+
+            // The mode indicator bits, which is a uint4 value (range 0 to 15).
+            internal uint ModeBits { get; }
+
+            // Number of character count bits for three different version ranges.
+            internal int[] NumBitsCharCount { get; }
+
+            // Returns the bit width of the character count field for a segment in this mode
+            // in a QR Code at the given version number. The result is in the range [0, 16].
+            internal int NumCharCountBits(int ver)
+            {
+                Debug.Assert(QrCode.MinVersion <= ver && ver <= QrCode.MaxVersion);
+                return NumBitsCharCount[(ver + 7) / 17];
+            }
+
+            private Mode(uint modeBits, params int[] numBitsCharCount)
+            {
+                ModeBits = modeBits;
+                NumBitsCharCount = numBitsCharCount;
+            }
+        }
+
+        #endregion
+
+    }
+
+}

--- a/dotnet/QrCodeGenerator/QrSegment.cs
+++ b/dotnet/QrCodeGenerator/QrSegment.cs
@@ -329,7 +329,7 @@ namespace Io.Nayuki.QrCodeGen
 
         // The set of all legal characters in alphanumeric mode, where
         // each character value maps to the index in the string.
-        static readonly string AlphanumericCharset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+        internal static readonly string AlphanumericCharset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
 
         #endregion
 

--- a/dotnet/QrCodeGenerator/QrSegment.cs
+++ b/dotnet/QrCodeGenerator/QrSegment.cs
@@ -28,7 +28,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// A segment of character/binary/control data in a QR Code symbol.

--- a/dotnet/QrCodeGenerator/QrSegmentAdvanced.cs
+++ b/dotnet/QrCodeGenerator/QrSegmentAdvanced.cs
@@ -1,0 +1,242 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using static Io.Nayuki.QrCodeGen.QrSegment;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// Splits text into optimal segments and encodes kanji segments.
+    /// </summary>
+    /// <remarks>
+    /// Provides static functions only; not instantiable.
+    /// </remarks>
+    /// <seealso cref="QrSegment"/>
+    /// <seealso cref="QrCode"/>
+    public static class QrSegmentAdvanced
+    {
+
+        #region Kanji mode segment encoder
+
+        /// <summary>
+        /// Returns a segment representing the specified text string encoded in kanji mode.
+        /// </summary>
+        /// <remarks>
+        /// Broadly speaking, the set of encodable characters are {kanji used in Japan,
+        /// hiragana, katakana, East Asian punctuation, full-width ASCII, Greek, Cyrillic}.
+        /// Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
+        /// more extensive Chinese hanzi}.
+        /// </remarks>
+        /// <param name="text">the text (not <c>null</c>), with only certain characters allowed</param>
+        /// <returns>a segment (not <c>null</c>) containing the text</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the string is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the string contains non-encodable characters</exception>
+        /// <seealso cref="IsEncodableAsKanji"/>
+        public static QrSegment MakeKanji(string text)
+        {
+            Objects.RequireNonNull(text);
+            var ba = new BitArray(0);
+
+            foreach (char t in text)
+            {
+                ushort val = UnicodeToQrKanji[t];
+                if (val == 0xffff)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(text), "String contains non-kanji-mode characters");
+                }
+
+                ba.AppendBits(val, 13);
+            }
+
+            return new QrSegment(Mode.Kanji, text.Length, ba);
+        }
+
+
+        /// <summary>
+        /// Tests whether the specified string can be encoded as a segment in kanji mode.
+        /// </summary>
+        /// <remarks>
+        /// Broadly speaking, the set of encodable characters are {kanji used in Japan,
+        /// hiragana, katakana, East Asian punctuation, full-width ASCII, Greek, Cyrillic}.
+        /// Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
+        /// more extensive Chinese hanzi}.
+        /// </remarks>
+        /// <param name="text">the string to test for encodability (not {@code null})</param>
+        /// <returns><c>true</c> iff each character is in the kanji mode character set</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the string is <c>null</c></exception>
+	    public static bool IsEncodableAsKanji(string text) {
+		    Objects.RequireNonNull(text);
+            foreach (char t in text)
+                if (!IsKanji(t))
+                    return false;
+
+            return true;
+	    }
+	    
+	    
+	    private static bool IsKanji(int c) {
+		    return c < UnicodeToQrKanji.Length && UnicodeToQrKanji[c] != 0xffff;
+	    }
+	    
+	        
+	    // Data derived from ftp://ftp.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/SHIFTJIS.TXT
+	    private const string PackedQrKanjiToUnicode =
+		    "MAAwATAC/wz/DjD7/xr/G/8f/wEwmzCcALT/QACo/z7/4/8/MP0w/jCdMJ4wA07dMAUwBjAHMPwgFSAQ/w8AXDAcIBb/XCAmICUgGCAZIBwgHf8I/wkwFDAV/zv/Pf9b/10wCDAJMAowCzAMMA0wDjAPMBAwEf8LIhIAsQDX//8A9/8dImD/HP8eImYiZyIeIjQmQiZA" +
+		    "ALAgMiAzIQP/5f8EAKIAo/8F/wP/Bv8K/yAApyYGJgUlyyXPJc4lxyXGJaEloCWzJbIlvSW8IDswEiGSIZAhkSGTMBP/////////////////////////////IggiCyKGIocigiKDIioiKf////////////////////8iJyIoAKwh0iHUIgAiA///////////////////" +
+		    "//////////8iICKlIxIiAiIHImEiUiJqImsiGiI9Ih0iNSIrIiz//////////////////yErIDAmbyZtJmogICAhALb//////////yXv/////////////////////////////////////////////////xD/Ef8S/xP/FP8V/xb/F/8Y/xn///////////////////8h" +
+		    "/yL/I/8k/yX/Jv8n/yj/Kf8q/yv/LP8t/y7/L/8w/zH/Mv8z/zT/Nf82/zf/OP85/zr///////////////////9B/0L/Q/9E/0X/Rv9H/0j/Sf9K/0v/TP9N/07/T/9Q/1H/Uv9T/1T/Vf9W/1f/WP9Z/1r//////////zBBMEIwQzBEMEUwRjBHMEgwSTBKMEswTDBN" +
+		    "ME4wTzBQMFEwUjBTMFQwVTBWMFcwWDBZMFowWzBcMF0wXjBfMGAwYTBiMGMwZDBlMGYwZzBoMGkwajBrMGwwbTBuMG8wcDBxMHIwczB0MHUwdjB3MHgweTB6MHswfDB9MH4wfzCAMIEwgjCDMIQwhTCGMIcwiDCJMIowizCMMI0wjjCPMJAwkTCSMJP/////////////" +
+		    "////////////////////////MKEwojCjMKQwpTCmMKcwqDCpMKowqzCsMK0wrjCvMLAwsTCyMLMwtDC1MLYwtzC4MLkwujC7MLwwvTC+ML8wwDDBMMIwwzDEMMUwxjDHMMgwyTDKMMswzDDNMM4wzzDQMNEw0jDTMNQw1TDWMNcw2DDZMNow2zDcMN0w3jDf//8w4DDh" +
+		    "MOIw4zDkMOUw5jDnMOgw6TDqMOsw7DDtMO4w7zDwMPEw8jDzMPQw9TD2/////////////////////wORA5IDkwOUA5UDlgOXA5gDmQOaA5sDnAOdA54DnwOgA6EDowOkA6UDpgOnA6gDqf////////////////////8DsQOyA7MDtAO1A7YDtwO4A7kDugO7A7wDvQO+" +
+		    "A78DwAPBA8MDxAPFA8YDxwPIA8n/////////////////////////////////////////////////////////////////////////////////////////////////////////////BBAEEQQSBBMEFAQVBAEEFgQXBBgEGQQaBBsEHAQdBB4EHwQgBCEEIgQjBCQEJQQm" +
+		    "BCcEKAQpBCoEKwQsBC0ELgQv////////////////////////////////////////BDAEMQQyBDMENAQ1BFEENgQ3BDgEOQQ6BDsEPAQ9//8EPgQ/BEAEQQRCBEMERARFBEYERwRIBEkESgRLBEwETQROBE///////////////////////////////////yUAJQIlDCUQ" +
+		    "JRglFCUcJSwlJCU0JTwlASUDJQ8lEyUbJRclIyUzJSslOyVLJSAlLyUoJTclPyUdJTAlJSU4JUL/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "/////////////////////////////////////06cVRZaA5Y/VMBhG2MoWfaQIoR1gxx6UGCqY+FuJWXthGaCppv1aJNXJ2WhYnFbm1nQhnuY9H1ifb6bjmIWfJ+It1uJXrVjCWaXaEiVx5eNZ09O5U8KT01PnVBJVvJZN1nUWgFcCWDfYQ9hcGYTaQVwunVPdXB5+32t" +
+		    "fe+Aw4QOiGOLApBVkHpTO06VTqVX34CykMF4704AWPFuopA4ejKDKIKLnC9RQVNwVL1U4VbgWftfFZjybeuA5IUt////////lmKWcJagl/tUC1PzW4dwz3+9j8KW6FNvnVx6uk4ReJOB/G4mVhhVBGsdhRqcO1nlU6ltZnTclY9WQk6RkEuW8oNPmQxT4VW2WzBfcWYg" +
+		    "ZvNoBGw4bPNtKXRbdsh6Tpg0gvGIW4pgku1tsnWrdsqZxWCmiwGNipWyaY5TrVGG//9XElgwWURbtF72YChjqWP0bL9vFHCOcRRxWXHVcz9+AYJ2gtGFl5BgkludG1hpZbxsWnUlUflZLlllX4Bf3GK8ZfpqKmsna7Rzi3/BiVadLJ0OnsRcoWyWg3tRBFxLYbaBxmh2" +
+		    "cmFOWU/6U3hgaW4pek+X804LUxZO7k9VTz1PoU9zUqBT71YJWQ9awVu2W+F50WaHZ5xntmtMbLNwa3PCeY15vno8e4eCsYLbgwSDd4Pvg9OHZoqyVimMqI/mkE6XHoaKT8Rc6GIRcll1O4Hlgr2G/ozAlsWZE5nVTstPGonjVt5YSljKXvtf62AqYJRgYmHQYhJi0GU5" +
+		    "////////m0FmZmiwbXdwcHVMdoZ9dYKlh/mVi5aOjJ1R8VK+WRZUs1uzXRZhaGmCba94jYTLiFeKcpOnmrhtbJmohtlXo2f/hs6SDlKDVodUBF7TYuFkuWg8aDhru3NyeLp6a4maidKNa48DkO2Vo5aUl2lbZlyzaX2YTZhOY5t7IGor//9qf2i2nA1vX1JyVZ1gcGLs" +
+		    "bTtuB27RhFuJEI9EThScOVP2aRtqOpeEaCpRXHrDhLKR3JOMVludKGgigwWEMXylUgiCxXTmTn5Pg1GgW9JSClLYUudd+1WaWCpZ5luMW5hb215yXnlgo2EfYWNhvmPbZWJn0WhTaPprPmtTbFdvIm+Xb0V0sHUYduN3C3r/e6F8IX3pfzZ/8ICdgmaDnomzisyMq5CE" +
+		    "lFGVk5WRlaKWZZfTmSiCGE44VCtcuF3Mc6l2THc8XKl/640LlsGYEZhUmFhPAU8OU3FVnFZoV/pZR1sJW8RckF4MXn5fzGPuZzpl12XiZx9oy2jE////////al9eMGvFbBdsfXV/eUhbY3oAfQBfvYmPihiMtI13jsyPHZjimg6bPE6AUH1RAFmTW5xiL2KAZOxrOnKg" +
+		    "dZF5R3+ph/uKvItwY6yDypegVAlUA1WraFRqWIpweCdndZ7NU3RbooEahlCQBk4YTkVOx08RU8pUOFuuXxNgJWVR//9nPWxCbHJs43B4dAN6dnquewh9Gnz+fWZl53JbU7tcRV3oYtJi4GMZbiCGWooxjd2S+G8BeaabWk6oTqtOrE+bT6BQ0VFHevZRcVH2U1RTIVN/" +
+		    "U+tVrFiDXOFfN19KYC9gUGBtYx9lWWpLbMFywnLtd++A+IEFggiFTpD3k+GX/5lXmlpO8FHdXC1mgWltXEBm8ml1c4loUHyBUMVS5FdHXf6TJmWkayNrPXQ0eYF5vXtLfcqCuYPMiH+JX4s5j9GR0VQfkoBOXVA2U+VTOnLXc5Z36YLmjq+ZxpnImdJRd2Eahl5VsHp6" +
+		    "UHZb05BHloVOMmrbkedcUVxI////////Y5h6n2yTl3SPYXqqcYqWiHyCaBd+cGhRk2xS8lQbhauKE3+kjs2Q4VNmiIh5QU/CUL5SEVFEVVNXLXPqV4tZUV9iX4RgdWF2YWdhqWOyZDplbGZvaEJuE3Vmej18+31MfZl+S39rgw6DSobNigiKY4tmjv2YGp2PgriPzpvo" +
+		    "//9Sh2IfZINvwJaZaEFQkWsgbHpvVHp0fVCIQIojZwhO9lA5UCZQZVF8UjhSY1WnVw9YBVrMXvphsmH4YvNjcmkcailyfXKscy54FHhvfXl3DICpiYuLGYzijtKQY5N1lnqYVZoTnnhRQ1OfU7Nee18mbhtukHOEc/59Q4I3igCK+pZQTk5QC1PkVHxW+lnRW2Rd8V6r" +
+		    "XydiOGVFZ69uVnLQfMqItIChgOGD8IZOioeN6JI3lseYZ58TTpROkk8NU0hUSVQ+Wi9fjF+hYJ9op2qOdFp4gYqeiqSLd5GQTl6byU6kT3xPr1AZUBZRSVFsUp9SuVL+U5pT41QR////////VA5ViVdRV6JZfVtUW11bj13lXedd9154XoNeml63XxhgUmFMYpdi2GOn" +
+		    "ZTtmAmZDZvRnbWghaJdpy2xfbSptaW4vbp11MnaHeGx6P3zgfQV9GH1efbGAFYADgK+AsYFUgY+CKoNSiEyIYYsbjKKM/JDKkXWScXg/kvyVpJZN//+YBZmZmtidO1JbUqtT91QIWNVi92/gjGqPX565UUtSO1RKVv16QJF3nWCe0nNEbwmBcHURX/1g2pqoctuPvGtk" +
+		    "mANOylbwV2RYvlpaYGhhx2YPZgZoOWixbfd11X06gm6bQk6bT1BTyVUGXW9d5l3uZ/tsmXRzeAKKUJOWiN9XUF6nYytQtVCsUY1nAFTJWF5Zu1uwX2liTWOhaD1rc24IcH2Rx3KAeBV4JnltZY59MIPciMGPCZabUmRXKGdQf2qMoVG0V0KWKlg6aYqAtFSyXQ5X/HiV" +
+		    "nfpPXFJKVItkPmYoZxRn9XqEe1Z9IpMvaFybrXs5UxlRilI3////////W99i9mSuZOZnLWu6hamW0XaQm9ZjTJMGm6t2v2ZSTglQmFPCXHFg6GSSZWNoX3Hmc8p1I3uXfoKGlYuDjNuReJkQZaxmq2uLTtVO1E86T39SOlP4U/JV41bbWOtZy1nJWf9bUFxNXgJeK1/X" +
+		    "YB1jB2UvW1xlr2W9ZehnnWti//9re2wPc0V5SXnBfPh9GX0rgKKBAoHziZaKXoppimaKjIrujMeM3JbMmPxrb06LTzxPjVFQW1db+mFIYwFmQmshbstsu3I+dL111HjBeTqADIAzgeqElI+ebFCef18Pi1idK3r6jvhbjZbrTgNT8Vf3WTFayVukYIluf28Gdb6M6luf" +
+		    "hQB74FByZ/SCnVxhhUp+HoIOUZlcBGNojWZlnHFueT59F4AFix2OypBuhseQqlAfUvpcOmdTcHxyNZFMkciTK4LlW8JfMWD5TjtT1luIYktnMWuKculz4HougWuNo5FSmZZRElPXVGpb/2OIajl9rJcAVtpTzlRo////////W5dcMV3eT+5hAWL+bTJ5wHnLfUJ+TX/S" +
+		    "ge2CH4SQiEaJcouQjnSPL5AxkUuRbJbGkZxOwE9PUUVTQV+TYg5n1GxBbgtzY34mkc2Sg1PUWRlbv23ReV1+LnybWH5xn1H6iFOP8E/KXPtmJXeseuOCHJn/UcZfqmXsaW9riW3z//9ulm9kdv59FF3hkHWRh5gGUeZSHWJAZpFm2W4aXrZ90n9yZviFr4X3ivhSqVPZ" +
+		    "WXNej1+QYFWS5JZkULdRH1LdUyBTR1PsVOhVRlUxVhdZaFm+WjxbtVwGXA9cEVwaXoReil7gX3Bif2KEYttjjGN3ZgdmDGYtZnZnfmiiah9qNWy8bYhuCW5YcTxxJnFndcd3AXhdeQF5ZXnweuB7EXynfTmAloPWhIuFSYhdiPOKH4o8ilSKc4xhjN6RpJJmk36UGJac" +
+		    "l5hOCk4ITh5OV1GXUnBXzlg0WMxbIl44YMVk/mdhZ1ZtRHK2dXN6Y4S4i3KRuJMgVjFX9Jj+////////Yu1pDWuWce1+VIB3gnKJ5pjfh1WPsVw7TzhP4U+1VQdaIFvdW+lfw2FOYy9lsGZLaO5pm214bfF1M3W5dx95XnnmfTOB44KvhaqJqoo6jquPm5Aykd2XB066" +
+		    "TsFSA1h1WOxcC3UaXD2BTooKj8WWY5dteyWKz5gIkWJW81Oo//+QF1Q5V4JeJWOobDRwindhfIt/4IhwkEKRVJMQkxiWj3RemsRdB11pZXBnoo2olttjbmdJaRmDxZgXlsCI/m+EZHpb+E4WcCx1XWYvUcRSNlLiWdNfgWAnYhBlP2V0Zh9mdGjyaBZrY24FcnJ1H3bb" +
+		    "fL6AVljwiP2Jf4qgipOKy5AdkZKXUpdZZYl6DoEGlrteLWDcYhplpWYUZ5B383pNfE1+PoEKjKyNZI3hjl94qVIHYtljpWRCYpiKLXqDe8CKrJbqfXaCDIdJTtlRSFNDU2Bbo1wCXBZd3WImYkdksGgTaDRsyW1FbRdn029ccU5xfWXLen97rX3a////////fkp/qIF6" +
+		    "ghuCOYWmim6Mzo31kHiQd5KtkpGVg5uuUk1VhG84cTZRaHmFflWBs3zOVkxYUVyoY6pm/mb9aVpy2XWPdY55DnlWed98l30gfUSGB4o0ljuQYZ8gUOdSdVPMU+JQCVWqWO5ZT3I9W4tcZFMdYONg82NcY4NjP2O7//9kzWXpZvld42nNaf1vFXHlTol16Xb4epN8333P" +
+		    "fZyAYYNJg1iEbIS8hfuIxY1wkAGQbZOXlxyaElDPWJdhjoHThTWNCJAgT8NQdFJHU3Ngb2NJZ19uLI2zkB9P11xejMplz32aU1KIllF2Y8NbWFtrXApkDWdRkFxO1lkaWSpscIpRVT5YFVmlYPBiU2fBgjVpVZZAmcSaKE9TWAZb/oAQXLFeL1+FYCBhS2I0Zv9s8G7e" +
+		    "gM6Bf4LUiIuMuJAAkC6Wip7bm9tO41PwWSd7LJGNmEyd+W7dcCdTU1VEW4ViWGKeYtNsom/vdCKKF5Q4b8GK/oM4UeeG+FPq////////U+lPRpBUj7BZaoExXf166o+/aNqMN3L4nEhqPYqwTjlTWFYGV2ZixWOiZeZrTm3hbltwrXfteu97qn27gD2AxobLipWTW1bj" +
+		    "WMdfPmWtZpZqgGu1dTeKx1Akd+VXMF8bYGVmemxgdfR6Gn9ugfSHGJBFmbN7yXVcevl7UYTE//+QEHnpepKDNlrhd0BOLU7yW5lf4GK9Zjxn8WzohmuId4o7kU6S85nQahdwJnMqgueEV4yvTgFRRlHLVYtb9V4WXjNegV8UXzVfa1+0YfJjEWaiZx1vbnJSdTp3OoB0" +
+		    "gTmBeId2ir+K3I2FjfOSmpV3mAKc5VLFY1d29GcVbIhzzYzDk66Wc20lWJxpDmnMj/2TmnXbkBpYWmgCY7Rp+09Dbyxn2I+7hSZ9tJNUaT9vcFdqWPdbLH0scipUCpHjnbROrU9OUFxQdVJDjJ5USFgkW5peHV6VXq1e918fYIxitWM6Y9Bor2xAeId5jnoLfeCCR4oC" +
+		    "iuaORJAT////////kLiRLZHYnw5s5WRYZOJldW70doR7G5Bpk9FuulTyX7lkpI9Nj+2SRFF4WGtZKVxVXpdt+36PdRyMvI7imFtwuU8da79vsXUwlvtRTlQQWDVYV1msXGBfkmWXZ1xuIXZ7g9+M7ZAUkP2TTXgleDpSql6mVx9ZdGASUBJRWlGs//9RzVIAVRBYVFhY" +
+		    "WVdblVz2XYtgvGKVZC1ncWhDaLxo33bXbdhub22bcG9xyF9Tddh5d3tJe1R7UnzWfXFSMIRjhWmF5IoOiwSMRo4PkAOQD5QZlnaYLZowldhQzVLVVAxYAlwOYadknm0ed7N65YD0hASQU5KFXOCdB1M/X5dfs22ccnl3Y3m/e+Rr0nLsiq1oA2phUfh6gWk0XEqc9oLr" +
+		    "W8WRSXAeVnhcb2DHZWZsjIxakEGYE1RRZseSDVlIkKNRhU5NUeqFmYsOcFhjepNLaWKZtH4EdXdTV2lgjt+W42xdToxcPF8Qj+lTAozRgImGeV7/ZeVOc1Fl////////WYJcP5fuTvtZil/Nio1v4XmweWJb54RxcytxsV50X/Vje2SaccN8mE5DXvxOS1fcVqJgqW/D" +
+		    "fQ2A/YEzgb+PsomXhqRd9GKKZK2Jh2d3bOJtPnQ2eDRaRn91gq2ZrE/zXsNi3WOSZVdnb3bDckyAzIC6jymRTVANV/lakmiF//9pc3Fkcv2Mt1jyjOCWapAZh3955HfnhClPL1JlU1pizWfPbMp2fXuUfJWCNoWEj+tm3W8gcgZ+G4OrmcGeplH9e7F4cnu4gId7SGro" +
+		    "XmGAjHVRdWBRa5Jibox2epGXmupPEH9wYpx7T5WlnOlWelhZhuSWvE80UiRTSlPNU9teBmQsZZFnf2w+bE5ySHKvc+11VH5BgiyF6Yype8SRxnFpmBKY72M9Zml1anbkeNCFQ4buUypTUVQmWYNeh198YLJiSWJ5YqtlkGvUbMx1snaueJF52H3Lf3eApYirirmMu5B/" +
+		    "l16Y22oLfDhQmVw+X65nh2vYdDV3CX+O////////nztnynoXUzl1i5rtX2aBnYPxgJhfPF/FdWJ7RpA8aGdZ61qbfRB2fossT/VfamoZbDdvAnTieWiIaIpVjHle32PPdcV50oLXkyiS8oSchu2cLVTBX2xljG1ccBWMp4zTmDtlT3T2Tg1O2FfgWStaZlvMUaheA16c" +
+		    "YBZidmV3//9lp2ZubW5yNnsmgVCBmoKZi1yMoIzmjXSWHJZET65kq2tmgh6EYYVqkOhcAWlTmKiEeoVXTw9Sb1+pXkVnDXmPgXmJB4mGbfVfF2JVbLhOz3Jpm5JSBlQ7VnRYs2GkYm5xGllufIl83n0blvBlh4BeThlPdVF1WEBeY15zXwpnxE4mhT2ViZZbfHOYAVD7" +
+		    "WMF2VninUiV3pYURe4ZQT1kJckd7x33oj7qP1JBNT79SyVopXwGXrU/dgheS6lcDY1VraXUriNyPFHpCUt9Yk2FVYgpmrmvNfD+D6VAjT/hTBVRGWDFZSVudXPBc710pXpZisWNnZT5luWcL////////bNVs4XD5eDJ+K4DegrOEDITshwKJEooqjEqQppLSmP2c851s" +
+		    "Tk9OoVCNUlZXSlmoXj1f2F/ZYj9mtGcbZ9Bo0lGSfSGAqoGoiwCMjIy/kn6WMlQgmCxTF1DVU1xYqGSyZzRyZ3dmekaR5lLDbKFrhlgAXkxZVGcsf/tR4XbG//9kaXjom1Seu1fLWblmJ2eaa85U6WnZXlWBnGeVm6pn/pxSaF1Opk/jU8hiuWcrbKuPxE+tfm2ev04H" +
+		    "YWJugG8rhRNUc2cqm0Vd83uVXKxbxoccbkqE0XoUgQhZmXyNbBF3IFLZWSJxIXJfd9uXJ51haQtaf1oYUaVUDVR9Zg5234/3kpic9Fnqcl1uxVFNaMl9v33sl2KeumR4aiGDAlmEW19r23MbdvJ9soAXhJlRMmcontl27mdiUv+ZBVwkYjt8foywVU9gtn0LlYBTAU5f" +
+		    "UbZZHHI6gDaRzl8ld+JThF95fQSFrIozjo2XVmfzha6UU2EJYQhsuXZS////////iu2POFUvT1FRKlLHU8tbpV59YKBhgmPWZwln2m5nbYxzNnM3dTF5UIjVipiQSpCRkPWWxIeNWRVOiE9ZTg6KiY8/mBBQrV58WZZbuV64Y9pj+mTBZtxpSmnYbQtutnGUdSh6r3+K" +
+		    "gACESYTJiYGLIY4KkGWWfZkKYX5ikWsy//9sg210f8x//G3Af4WHuoj4Z2WDsZg8lvdtG31hhD2Rak5xU3VdUGsEb+uFzYYtiadSKVQPXGVnTmiodAZ0g3XiiM+I4ZHMluKWeF+Lc4d6y4ROY6B1ZVKJbUFunHQJdVl4a3ySloZ63J+NT7ZhbmXFhlxOhk6uUNpOIVHM" +
+		    "W+5lmWiBbbxzH3ZCd616HHzngm+K0pB8kc+WdZgYUpt90VArU5hnl23LcdB0M4HojyqWo5xXnp90YFhBbZl9L5heTuRPNk+LUbdSsV26YBxzsnk8gtOSNJa3lvaXCp6Xn2Jmpmt0UhdSo3DIiMJeyWBLYZBvI3FJfD599IBv////////hO6QI5MsVEKbb2rTcImMwo3v" +
+		    "lzJStFpBXspfBGcXaXxplG1qbw9yYnL8e+2AAYB+h0uQzlFtnpN5hICLkzKK1lAtVIyKcWtqjMSBB2DRZ6Cd8k6ZTpicEIprhcGFaGkAbn54l4FV////////////////////////////////////////////////////////////////////////////////////////" +
+		    "/////////////////////////////18MThBOFU4qTjFONk48Tj9OQk5WTlhOgk6FjGtOioISXw1Ojk6eTp9OoE6iTrBOs062Ts5OzU7ETsZOwk7XTt5O7U7fTvdPCU9aTzBPW09dT1dPR092T4hPj0+YT3tPaU9wT5FPb0+GT5ZRGE/UT99Pzk/YT9tP0U/aT9BP5E/l" +
+		    "UBpQKFAUUCpQJVAFTxxP9lAhUClQLE/+T+9QEVAGUENQR2cDUFVQUFBIUFpQVlBsUHhQgFCaUIVQtFCy////////UMlQylCzUMJQ1lDeUOVQ7VDjUO5Q+VD1UQlRAVECURZRFVEUURpRIVE6UTdRPFE7UT9RQFFSUUxRVFFievhRaVFqUW5RgFGCVthRjFGJUY9RkVGT" +
+		    "UZVRllGkUaZRolGpUapRq1GzUbFRslGwUbVRvVHFUclR21HghlVR6VHt//9R8FH1Uf5SBFILUhRSDlInUipSLlIzUjlST1JEUktSTFJeUlRSalJ0UmlSc1J/Un1SjVKUUpJScVKIUpGPqI+nUqxSrVK8UrVSwVLNUtdS3lLjUuaY7VLgUvNS9VL4UvlTBlMIdThTDVMQ" +
+		    "Uw9TFVMaUyNTL1MxUzNTOFNAU0ZTRU4XU0lTTVHWU15TaVNuWRhTe1N3U4JTllOgU6ZTpVOuU7BTtlPDfBKW2VPfZvxx7lPuU+hT7VP6VAFUPVRAVCxULVQ8VC5UNlQpVB1UTlSPVHVUjlRfVHFUd1RwVJJUe1SAVHZUhFSQVIZUx1SiVLhUpVSsVMRUyFSo////////" +
+		    "VKtUwlSkVL5UvFTYVOVU5lUPVRRU/VTuVO1U+lTiVTlVQFVjVUxVLlVcVUVVVlVXVThVM1VdVZlVgFSvVYpVn1V7VX5VmFWeVa5VfFWDValVh1WoVdpVxVXfVcRV3FXkVdRWFFX3VhZV/lX9VhtV+VZOVlBx31Y0VjZWMlY4//9Wa1ZkVi9WbFZqVoZWgFaKVqBWlFaP" +
+		    "VqVWrla2VrRWwla8VsFWw1bAVshWzlbRVtNW11buVvlXAFb/VwRXCVcIVwtXDVcTVxhXFlXHVxxXJlc3VzhXTlc7V0BXT1dpV8BXiFdhV39XiVeTV6BXs1ekV6pXsFfDV8ZX1FfSV9NYClfWV+NYC1gZWB1YclghWGJYS1hwa8BYUlg9WHlYhVi5WJ9Yq1i6WN5Yu1i4" +
+		    "WK5YxVjTWNFY11jZWNhY5VjcWORY31jvWPpY+Vj7WPxY/VkCWQpZEFkbaKZZJVksWS1ZMlk4WT560llVWVBZTllaWVhZYllgWWdZbFlp////////WXhZgVmdT15Pq1mjWbJZxlnoWdxZjVnZWdpaJVofWhFaHFoJWhpaQFpsWklaNVo2WmJaalqaWrxavlrLWsJavVrj" +
+		    "Wtda5lrpWtZa+lr7WwxbC1sWWzJa0FsqWzZbPltDW0VbQFtRW1VbWltbW2VbaVtwW3NbdVt4ZYhbeluA//9bg1umW7hbw1vHW8lb1FvQW+Rb5lviW95b5VvrW/Bb9lvzXAVcB1wIXA1cE1wgXCJcKFw4XDlcQVxGXE5cU1xQXE9bcVxsXG5OYlx2XHlcjFyRXJRZm1yr" +
+		    "XLtctly8XLdcxVy+XMdc2VzpXP1c+lztXYxc6l0LXRVdF11cXR9dG10RXRRdIl0aXRldGF1MXVJdTl1LXWxdc112XYddhF2CXaJdnV2sXa5dvV2QXbddvF3JXc1d013SXdZd213rXfJd9V4LXhpeGV4RXhteNl43XkReQ15AXk5eV15UXl9eYl5kXkdedV52XnqevF5/" +
+		    "XqBewV7CXshe0F7P////////XtZe417dXtpe217iXuFe6F7pXuxe8V7zXvBe9F74Xv5fA18JX11fXF8LXxFfFl8pXy1fOF9BX0hfTF9OXy9fUV9WX1dfWV9hX21fc193X4Nfgl9/X4pfiF+RX4dfnl+ZX5hfoF+oX61fvF/WX/tf5F/4X/Ff3WCzX/9gIWBg//9gGWAQ" +
+		    "YClgDmAxYBtgFWArYCZgD2A6YFpgQWBqYHdgX2BKYEZgTWBjYENgZGBCYGxga2BZYIFgjWDnYINgmmCEYJtglmCXYJJgp2CLYOFguGDgYNNgtF/wYL1gxmC1YNhhTWEVYQZg9mD3YQBg9GD6YQNhIWD7YPFhDWEOYUdhPmEoYSdhSmE/YTxhLGE0YT1hQmFEYXNhd2FY" +
+		    "YVlhWmFrYXRhb2FlYXFhX2FdYVNhdWGZYZZhh2GsYZRhmmGKYZFhq2GuYcxhymHJYfdhyGHDYcZhumHLf3lhzWHmYeNh9mH6YfRh/2H9Yfxh/mIAYghiCWINYgxiFGIb////////Yh5iIWIqYi5iMGIyYjNiQWJOYl5iY2JbYmBiaGJ8YoJiiWJ+YpJik2KWYtRig2KU" +
+		    "Ytdi0WK7Ys9i/2LGZNRiyGLcYsxiymLCYsdim2LJYwxi7mLxYydjAmMIYu9i9WNQYz5jTWQcY09jlmOOY4Bjq2N2Y6Njj2OJY59jtWNr//9jaWO+Y+ljwGPGY+NjyWPSY/ZjxGQWZDRkBmQTZCZkNmUdZBdkKGQPZGdkb2R2ZE5lKmSVZJNkpWSpZIhkvGTaZNJkxWTH" +
+		    "ZLtk2GTCZPFk54IJZOBk4WKsZONk72UsZPZk9GTyZPplAGT9ZRhlHGUFZSRlI2UrZTRlNWU3ZTZlOHVLZUhlVmVVZU1lWGVeZV1lcmV4ZYJlg4uKZZtln2WrZbdlw2XGZcFlxGXMZdJl22XZZeBl4WXxZ3JmCmYDZftnc2Y1ZjZmNGYcZk9mRGZJZkFmXmZdZmRmZ2Zo" +
+		    "Zl9mYmZwZoNmiGaOZolmhGaYZp1mwWa5Zslmvma8////////ZsRmuGbWZtpm4GY/ZuZm6WbwZvVm92cPZxZnHmcmZyeXOGcuZz9nNmdBZzhnN2dGZ15nYGdZZ2NnZGeJZ3BnqWd8Z2pnjGeLZ6ZnoWeFZ7dn72e0Z+xns2fpZ7hn5GfeZ91n4mfuZ7lnzmfGZ+dqnGge" +
+		    "aEZoKWhAaE1oMmhO//9os2graFloY2h3aH9on2iPaK1olGidaJtog2quaLlodGi1aKBoumkPaI1ofmkBaMppCGjYaSJpJmjhaQxozWjUaOdo1Wk2aRJpBGjXaONpJWj5aOBo72koaSppGmkjaSFoxml5aXdpXGl4aWtpVGl+aW5pOWl0aT1pWWkwaWFpXmldaYFpammy" +
+		    "aa5p0Gm/acFp02m+ac5b6GnKad1pu2nDaadqLmmRaaBpnGmVabRp3mnoagJqG2n/awpp+WnyaedqBWmxah5p7WoUaetqCmoSasFqI2oTakRqDGpyajZqeGpHamJqWWpmakhqOGoiapBqjWqgaoRqomqj////////apeGF2q7asNqwmq4arNqrGreatFq32qqatpq6mr7" +
+		    "awWGFmr6axJrFpsxax9rOGs3dtxrOZjua0drQ2tJa1BrWWtUa1trX2tha3hreWt/a4BrhGuDa41rmGuVa55rpGuqa6trr2uya7Frs2u3a7xrxmvLa9Nr32vsa+tr82vv//+evmwIbBNsFGwbbCRsI2xebFVsYmxqbIJsjWyabIFsm2x+bGhsc2ySbJBsxGzxbNNsvWzX" +
+		    "bMVs3WyubLFsvmy6bNts72zZbOptH4hNbTZtK209bThtGW01bTNtEm0MbWNtk21kbVpteW1ZbY5tlW/kbYVt+W4VbgpttW3HbeZtuG3Gbext3m3Mbeht0m3Fbfpt2W3kbdVt6m3ubi1ubm4ubhlucm5fbj5uI25rbitudm5Nbh9uQ246bk5uJG7/bh1uOG6CbqpumG7J" +
+		    "brdu0269bq9uxG6ybtRu1W6PbqVuwm6fb0FvEXBMbuxu+G7+bz9u8m8xbu9vMm7M////////bz5vE273b4Zvem94b4FvgG9vb1tv829tb4JvfG9Yb45vkW/Cb2Zvs2+jb6FvpG+5b8Zvqm/fb9Vv7G/Ub9hv8W/ub9twCXALb/pwEXABcA9v/nAbcBpvdHAdcBhwH3Aw" +
+		    "cD5wMnBRcGNwmXCScK9w8XCscLhws3CucN9wy3Dd//9w2XEJcP1xHHEZcWVxVXGIcWZxYnFMcVZxbHGPcftxhHGVcahxrHHXcblxvnHScclx1HHOceBx7HHncfVx/HH5cf9yDXIQchtyKHItcixyMHIycjtyPHI/ckByRnJLclhydHJ+coJygXKHcpJylnKicqdyuXKy" +
+		    "csNyxnLEcs5y0nLicuBy4XL5cvdQD3MXcwpzHHMWcx1zNHMvcylzJXM+c05zT57Yc1dzanNoc3BzeHN1c3tzenPIc7NzznO7c8Bz5XPuc950onQFdG90JXP4dDJ0OnRVdD90X3RZdEF0XHRpdHB0Y3RqdHZ0fnSLdJ50p3TKdM901HPx////////dOB043TndOl07nTy" +
+		    "dPB08XT4dPd1BHUDdQV1DHUOdQ11FXUTdR51JnUsdTx1RHVNdUp1SXVbdUZ1WnVpdWR1Z3VrdW11eHV2dYZ1h3V0dYp1iXWCdZR1mnWddaV1o3XCdbN1w3W1db11uHW8dbF1zXXKddJ12XXjdd51/nX///91/HYBdfB1+nXydfN2C3YNdgl2H3YndiB2IXYidiR2NHYw" +
+		    "djt2R3ZIdkZ2XHZYdmF2YnZodml2anZndmx2cHZydnZ2eHZ8doB2g3aIdot2jnaWdpN2mXaadrB2tHa4drl2unbCds121nbSdt524Xbldud26oYvdvt3CHcHdwR3KXckdx53JXcmdxt3N3c4d0d3Wndod2t3W3dld393fnd5d453i3eRd6B3nnewd7Z3uXe/d7x3vXe7" +
+		    "d8d3zXfXd9p33Hfjd+53/HgMeBJ5JnggeSp4RXiOeHR4hnh8eJp4jHijeLV4qniveNF4xnjLeNR4vni8eMV4ynjs////////eOd42nj9ePR5B3kSeRF5GXkseSt5QHlgeVd5X3laeVV5U3l6eX95inmdeaefS3mqea55s3m5ebp5yXnVeed57HnheeN6CHoNehh6GXog" +
+		    "eh95gHoxejt6Pno3ekN6V3pJemF6Ynppn516cHp5en16iHqXepV6mHqWeql6yHqw//96tnrFesR6v5CDesd6ynrNes961XrTetl62nrdeuF64nrmeu168HsCew97CnsGezN7GHsZex57NXsoezZ7UHt6ewR7TXsLe0x7RXt1e2V7dHtne3B7cXtse257nXuYe597jXuc" +
+		    "e5p7i3uSe497XXuZe8t7wXvMe897tHvGe9176XwRfBR75nvlfGB8AHwHfBN783v3fBd8DXv2fCN8J3wqfB98N3wrfD18THxDfFR8T3xAfFB8WHxffGR8VnxlfGx8dXyDfJB8pHytfKJ8q3yhfKh8s3yyfLF8rny5fL18wHzFfMJ82HzSfNx84ps7fO988nz0fPZ8+n0G" +
+		    "////////fQJ9HH0VfQp9RX1LfS59Mn0/fTV9Rn1zfVZ9Tn1yfWh9bn1PfWN9k32JfVt9j319fZt9un2ufaN9tX3Hfb19q349faJ9r33cfbh9n32wfdh93X3kfd59+33yfeF+BX4KfiN+IX4SfjF+H34Jfgt+In5GfmZ+O341fjl+Q343//9+Mn46fmd+XX5Wfl5+WX5a" +
+		    "fnl+an5pfnx+e36DfdV+fY+ufn9+iH6Jfox+kn6QfpN+lH6Wfo5+m36cfzh/On9Ff0x/TX9Of1B/UX9Vf1R/WH9ff2B/aH9pf2d/eH+Cf4Z/g3+If4d/jH+Uf55/nX+af6N/r3+yf7l/rn+2f7iLcX/Ff8Z/yn/Vf9R/4X/mf+l/83/5mNyABoAEgAuAEoAYgBmAHIAh" +
+		    "gCiAP4A7gEqARoBSgFiAWoBfgGKAaIBzgHKAcIB2gHmAfYB/gISAhoCFgJuAk4CagK1RkICsgNuA5YDZgN2AxIDagNaBCYDvgPGBG4EpgSOBL4FL////////louBRoE+gVOBUYD8gXGBboFlgWaBdIGDgYiBioGAgYKBoIGVgaSBo4FfgZOBqYGwgbWBvoG4gb2BwIHC" +
+		    "gbqByYHNgdGB2YHYgciB2oHfgeCB54H6gfuB/oIBggKCBYIHggqCDYIQghaCKYIrgjiCM4JAglmCWIJdglqCX4Jk//+CYoJogmqCa4IugnGCd4J4gn6CjYKSgquCn4K7gqyC4YLjgt+C0oL0gvOC+oOTgwOC+4L5gt6DBoLcgwmC2YM1gzSDFoMygzGDQIM5g1CDRYMv" +
+		    "gyuDF4MYg4WDmoOqg5+DooOWgyODjoOHg4qDfIO1g3ODdYOgg4mDqIP0hBOD64POg/2EA4PYhAuDwYP3hAeD4IPyhA2EIoQgg72EOIUGg/uEbYQqhDyFWoSEhHeEa4SthG6EgoRphEaELIRvhHmENYTKhGKEuYS/hJ+E2YTNhLuE2oTQhMGExoTWhKGFIYT/hPSFF4UY" +
+		    "hSyFH4UVhRSE/IVAhWOFWIVI////////hUGGAoVLhVWFgIWkhYiFkYWKhaiFbYWUhZuF6oWHhZyFd4V+hZCFyYW6hc+FuYXQhdWF3YXlhdyF+YYKhhOGC4X+hfqGBoYihhqGMIY/hk1OVYZUhl+GZ4ZxhpOGo4aphqqGi4aMhraGr4bEhsaGsIbJiCOGq4bUht6G6Ybs" +
+		    "//+G34bbhu+HEocGhwiHAIcDhvuHEYcJhw2G+YcKhzSHP4c3hzuHJYcphxqHYIdfh3iHTIdOh3SHV4doh26HWYdTh2OHaogFh6KHn4eCh6+Hy4e9h8CH0JbWh6uHxIezh8eHxoe7h++H8ofgiA+IDYf+h/aH94gOh9KIEYgWiBWIIoghiDGINog5iCeIO4hEiEKIUohZ" +
+		    "iF6IYohriIGIfoieiHWIfYi1iHKIgoiXiJKIroiZiKKIjYikiLCIv4ixiMOIxIjUiNiI2YjdiPmJAoj8iPSI6IjyiQSJDIkKiROJQ4keiSWJKokriUGJRIk7iTaJOIlMiR2JYIle////////iWaJZIltiWqJb4l0iXeJfomDiYiJiomTiZiJoYmpiaaJrImvibKJuom9" +
+		    "ib+JwInaidyJ3YnnifSJ+IoDihaKEIoMihuKHYolijaKQYpbilKKRopIinyKbYpsimKKhYqCioSKqIqhipGKpYqmipqKo4rEis2KworaiuuK84rn//+K5IrxixSK4IriiveK3orbiwyLB4saiuGLFosQixeLIIszl6uLJosriz6LKItBi0yLT4tOi0mLVotbi1qLa4tf" +
+		    "i2yLb4t0i32LgIuMi46LkouTi5aLmYuajDqMQYw/jEiMTIxOjFCMVYxijGyMeIx6jIKMiYyFjIqMjYyOjJSMfIyYYh2MrYyqjL2MsoyzjK6MtozIjMGM5IzjjNqM/Yz6jPuNBI0FjQqNB40PjQ2NEJ9OjROMzY0UjRaNZ41tjXGNc42BjZmNwo2+jbqNz43ajdaNzI3b" +
+		    "jcuN6o3rjd+N4438jgiOCY3/jh2OHo4Qjh+OQo41jjCONI5K////////jkeOSY5MjlCOSI5ZjmSOYI4qjmOOVY52jnKOfI6BjoeOhY6EjouOio6TjpGOlI6ZjqqOoY6sjrCOxo6xjr6OxY7IjsuO247jjvyO+47rjv6PCo8FjxWPEo8ZjxOPHI8fjxuPDI8mjzOPO485" +
+		    "j0WPQo8+j0yPSY9Gj06PV49c//+PYo9jj2SPnI+fj6OPrY+vj7eP2o/lj+KP6o/vkIeP9JAFj/mP+pARkBWQIZANkB6QFpALkCeQNpA1kDmP+JBPkFCQUZBSkA6QSZA+kFaQWJBekGiQb5B2lqiQcpCCkH2QgZCAkIqQiZCPkKiQr5CxkLWQ4pDkYkiQ25ECkRKRGZEy" +
+		    "kTCRSpFWkViRY5FlkWmRc5FykYuRiZGCkaKRq5GvkaqRtZG0kbqRwJHBkcmRy5HQkdaR35HhkduR/JH1kfaSHpH/khSSLJIVkhGSXpJXkkWSSZJkkkiSlZI/kkuSUJKckpaSk5KbklqSz5K5kreS6ZMPkvqTRJMu////////kxmTIpMakyOTOpM1kzuTXJNgk3yTbpNW" +
+		    "k7CTrJOtk5STuZPWk9eT6JPlk9iTw5Pdk9CTyJPklBqUFJQTlAOUB5QQlDaUK5Q1lCGUOpRBlFKURJRblGCUYpRelGqSKZRwlHWUd5R9lFqUfJR+lIGUf5WClYeVipWUlZaVmJWZ//+VoJWolaeVrZW8lbuVuZW+lcpv9pXDlc2VzJXVldSV1pXcleGV5ZXiliGWKJYu" +
+		    "li+WQpZMlk+WS5Z3llyWXpZdll+WZpZylmyWjZaYlpWWl5aqlqeWsZaylrCWtJa2lriWuZbOlsuWyZbNiU2W3JcNltWW+ZcElwaXCJcTlw6XEZcPlxaXGZcklyqXMJc5lz2XPpdEl0aXSJdCl0mXXJdgl2SXZpdoUtKXa5dxl3mXhZd8l4GXepeGl4uXj5eQl5yXqJem" +
+		    "l6OXs5e0l8OXxpfIl8uX3Jftn0+X8nrfl/aX9ZgPmAyYOJgkmCGYN5g9mEaYT5hLmGuYb5hw////////mHGYdJhzmKqYr5ixmLaYxJjDmMaY6ZjrmQOZCZkSmRSZGJkhmR2ZHpkkmSCZLJkumT2ZPplCmUmZRZlQmUuZUZlSmUyZVZmXmZiZpZmtma6ZvJnfmduZ3ZnY" +
+		    "mdGZ7ZnumfGZ8pn7mfiaAZoPmgWZ4poZmiuaN5pFmkKaQJpD//+aPppVmk2aW5pXml+aYpplmmSaaZprmmqarZqwmryawJrPmtGa05rUmt6a35rimuOa5prvmuua7pr0mvGa95r7mwabGJsamx+bIpsjmyWbJ5somymbKpsumy+bMptEm0ObT5tNm06bUZtYm3Sbk5uD" +
+		    "m5GblpuXm5+boJuom7SbwJvKm7mbxpvPm9Gb0pvjm+Kb5JvUm+GcOpvym/Gb8JwVnBScCZwTnAycBpwInBKcCpwEnC6cG5wlnCScIZwwnEecMpxGnD6cWpxgnGecdpx4nOec7JzwnQmdCJzrnQOdBp0qnSadr50jnR+dRJ0VnRKdQZ0/nT6dRp1I////////nV2dXp1k" +
+		    "nVGdUJ1ZnXKdiZ2Hnaudb516nZqdpJ2pnbKdxJ3BnbuduJ26ncadz53Cndmd0534nead7Z3vnf2eGp4bnh6edZ55nn2egZ6InouejJ6SnpWekZ6dnqWeqZ64nqqerZdhnsyezp7PntCe1J7cnt6e3Z7gnuWe6J7v//+e9J72nvee+Z77nvye/Z8Hnwh2t58VnyGfLJ8+" +
+		    "n0qfUp9Un2OfX59gn2GfZp9nn2yfap93n3Kfdp+Vn5yfoFgvaceQWXRkUdxxmf//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		    "/////////////////////////////////////////////w==";
+	    
+	        
+	    private static readonly ushort[] UnicodeToQrKanji = new ushort[1 << 16];
+	    
+	    static QrSegmentAdvanced()
+        {
+            // Unpack the Shift JIS table into a more computation-friendly form
+            for (var i = 0; i < UnicodeToQrKanji.Length; i++)
+                UnicodeToQrKanji[i] = 0xffff;
+
+            byte[] bytes = Convert.FromBase64String(PackedQrKanjiToUnicode);
+		    for (var i = 0; i < bytes.Length; i += 2) {
+			    int c = (bytes[i] << 8) | bytes[i + 1];
+			    if (c == 0xFFFF)
+				    continue;
+			    Debug.Assert(UnicodeToQrKanji[c] == 0xffff);
+			    UnicodeToQrKanji[c] = (ushort)(i / 2);
+		    }
+	    }
+
+        #endregion 
+
+	
+    }
+}

--- a/dotnet/QrCodeGenerator/QrSegmentAdvanced.cs
+++ b/dotnet/QrCodeGenerator/QrSegmentAdvanced.cs
@@ -27,9 +27,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using static Io.Nayuki.QrCodeGen.QrSegment;
+using static IO.Nayuki.QrCodeGen.QrSegment;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// Splits text into optimal segments and encodes kanji segments.

--- a/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
+++ b/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
@@ -1,0 +1,144 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+
+using System;
+using System.Diagnostics;
+
+namespace Io.Nayuki.QrCodeGen
+{
+    /// <summary>
+    /// Computes the Reed-Solomon error correction codewords for a sequence of data codewords at a given degree.
+    /// </summary>
+    /// <remarks>
+    /// Objects are immutable, and the state only depends on the degree.
+    /// This class exists because each data block in a QR Code shares the same the divisor polynomial.
+    /// </remarks>
+    internal class ReedSolomonGenerator
+    {
+        #region Fields
+
+        // Coefficients of the divisor polynomial, stored from highest to lowest power, excluding the leading term which
+        // is always 1. For example the polynomial x^3 + 255x^2 + 8x + 93 is stored as the uint8 array {255, 8, 93}.
+        private readonly byte[] _coefficients;
+
+        #endregion
+
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructs a Reed-Solomon ECC generator for the specified degree. This could be implemented
+        /// as a lookup table over all possible parameter values, instead of as an algorithm.
+        /// </summary>
+        /// <param name="degree">the divisor polynomial degree, which must be between 1 and 255 (inclusive)</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if degree &lt; 1 or degree > 255</exception>
+        internal ReedSolomonGenerator(int degree)
+        {
+            if (degree < 1 || degree > 255)
+            {
+                throw new ArgumentOutOfRangeException(nameof(degree), "Degree out of range");
+            }
+
+            // Start with the monomial x^0
+            _coefficients = new byte[degree];
+            _coefficients[degree - 1] = 1;
+
+            // Compute the product polynomial (x - r^0) * (x - r^1) * (x - r^2) * ... * (x - r^{degree-1}),
+            // drop the highest term, and store the rest of the coefficients in order of descending powers.
+            // Note that r = 0x02, which is a generator element of this field GF(2^8/0x11D).
+            uint root = 1;
+            for (int i = 0; i < degree; i++)
+            {
+                // Multiply the current product by (x - r^i)
+                for (int j = 0; j < _coefficients.Length; j++)
+                {
+                    _coefficients[j] = Multiply(_coefficients[j], root);
+                    if (j + 1 < _coefficients.Length)
+                    {
+                        _coefficients[j] ^= _coefficients[j + 1];
+                    }
+                }
+                root = Multiply(root, 0x02);
+            }
+        }
+
+        #endregion
+
+
+        #region Methods
+
+        /// <summary>
+        /// Computes and returns the Reed-Solomon error correction codewords for the specified
+        /// sequence of data codewords.
+        /// </summary>
+        /// <remarks>
+        /// The returned object is always a new byte array.
+        /// This method does not alter this object's state (because it is immutable).
+        /// </remarks>
+        /// <param name="data">the sequence of data codewords</param>
+        /// <returns>the Reed-Solomon error correction codewords</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the data is <c>null</c></exception>
+        internal byte[] GetRemainder(byte[] data)
+        {
+            Objects.RequireNonNull(data);
+
+            // Compute the remainder by performing polynomial division
+            byte[] result = new byte[_coefficients.Length];
+            foreach (byte b in data)
+            {
+                uint factor = (uint)(b ^ result[0]);
+                Array.Copy(result, 1, result, 0, result.Length - 1);
+                result[result.Length - 1] = 0;
+                for (int i = 0; i < result.Length; i++)
+                {
+                    result[i] ^= Multiply(_coefficients[i], factor);
+                }
+            }
+            return result;
+        }
+
+        #endregion
+
+
+        #region Static functions
+
+        // Returns the product of the two given field elements modulo GF(2^8/0x11D). The arguments and result
+        // are unsigned 8-bit integers. This could be implemented as a lookup table of 256*256 entries of uint8.
+        private static byte Multiply(uint x, uint y)
+        {
+            Debug.Assert((x >> 8) == 0 && (y >> 8) == 0);
+            // Russian peasant multiplication
+            uint z = 0;
+            for (int i = 7; i >= 0; i--)
+            {
+                z = (z << 1) ^ ((z >> 7) * 0x11D);
+                z ^= ((y >> i) & 1) * x;
+            }
+            Debug.Assert((z >> 8) == 0);
+            return (byte)z;
+        }
+
+        #endregion
+    }
+}

--- a/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
+++ b/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
@@ -25,7 +25,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Io.Nayuki.QrCodeGen
+namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// Computes the Reed-Solomon error correction codewords for a sequence of data codewords at a given degree.

--- a/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
+++ b/dotnet/QrCodeGenerator/ReedSolomonGenerator.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -29,11 +29,11 @@ namespace IO.Nayuki.QrCodeGen
 {
     /// <summary>
     /// Computes the Reed-Solomon error correction codewords for a sequence of data codewords at a given degree.
+    /// <para>
+    /// Instances are immutable, and the state only depends on the degree.
+    /// This class is useful because all data blocks in a QR code share the same the divisor polynomial.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Objects are immutable, and the state only depends on the degree.
-    /// This class exists because each data block in a QR Code shares the same the divisor polynomial.
-    /// </remarks>
     internal class ReedSolomonGenerator
     {
         #region Fields
@@ -48,11 +48,13 @@ namespace IO.Nayuki.QrCodeGen
         #region Constructors
 
         /// <summary>
-        /// Constructs a Reed-Solomon ECC generator for the specified degree. This could be implemented
-        /// as a lookup table over all possible parameter values, instead of as an algorithm.
+        /// Initializes a new Reed-Solomon ECC generator for the specified degree. 
         /// </summary>
-        /// <param name="degree">the divisor polynomial degree, which must be between 1 and 255 (inclusive)</param>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if degree &lt; 1 or degree > 255</exception>
+        /// <remarks>
+        /// This could be implemented as a lookup table over all possible parameter values, instead of as an algorithm.
+        /// </remarks>
+        /// <param name="degree">The divisor polynomial degree (between 1 and 255).</param>
+        /// <exception cref="ArgumentOutOfRangeException"><c>degree</c> &lt; 1 or <c>degree</c> &gt; 255</exception>
         internal ReedSolomonGenerator(int degree)
         {
             if (degree < 1 || degree > 255)
@@ -89,16 +91,15 @@ namespace IO.Nayuki.QrCodeGen
         #region Methods
 
         /// <summary>
-        /// Computes and returns the Reed-Solomon error correction codewords for the specified
+        /// Computes the Reed-Solomon error correction codewords for the specified
         /// sequence of data codewords.
+        /// <para>
+        /// This method does not alter this object's state (as it is immutable).
+        /// </para>
         /// </summary>
-        /// <remarks>
-        /// The returned object is always a new byte array.
-        /// This method does not alter this object's state (because it is immutable).
-        /// </remarks>
-        /// <param name="data">the sequence of data codewords</param>
-        /// <returns>the Reed-Solomon error correction codewords</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the data is <c>null</c></exception>
+        /// <param name="data">The sequence of data codewords.</param>
+        /// <returns>The Reed-Solomon error correction codewords, as a byte array.</returns>
+        /// <exception cref="ArgumentNullException">If <c>data</c> is <c>null</c>.</exception>
         internal byte[] GetRemainder(byte[] data)
         {
             Objects.RequireNonNull(data);
@@ -127,7 +128,7 @@ namespace IO.Nayuki.QrCodeGen
         // are unsigned 8-bit integers. This could be implemented as a lookup table of 256*256 entries of uint8.
         private static byte Multiply(uint x, uint y)
         {
-            Debug.Assert((x >> 8) == 0 && (y >> 8) == 0);
+            Debug.Assert(x >> 8 == 0 && y >> 8 == 0);
             // Russian peasant multiplication
             uint z = 0;
             for (int i = 7; i >= 0; i--)
@@ -135,7 +136,7 @@ namespace IO.Nayuki.QrCodeGen
                 z = (z << 1) ^ ((z >> 7) * 0x11D);
                 z ^= ((y >> i) & 1) * x;
             }
-            Debug.Assert((z >> 8) == 0);
+            Debug.Assert(z >> 8 == 0);
             return (byte)z;
         }
 

--- a/dotnet/QrCodeGenerator/docfx/api/index.md
+++ b/dotnet/QrCodeGenerator/docfx/api/index.md
@@ -1,35 +1,38 @@
-# Swiss QR Bill for .NET Reference Documentation
+# QR Code generator library for .NET
 
-## Reference Documentation
+Generates QR codes from text strings and byte arrays.
 
-**[Codecrete.SwissQRBill.Generator.QRBill](xref:Codecrete.SwissQRBill.Generator.QRBill)**: Generates Swiss QR bill (receipt and payment part). Also validates the bill data and encode and decode the text embedded in the QR code.
-
-**[Codecrete.SwissQRBill.Generator.QRBill](xref:Codecrete.SwissQRBill.Generator.Bill)**: QR bill data as input for generation or output from decoding
-
-**[Codecrete.SwissQRBill.Generator.Payments](xref:Codecrete.SwissQRBill.Generator.Payments)**: Utility for generating and validation payment related data such as IBAN and reference numbers.
-
-[All types and classes](xref:Codecrete.SwissQRBill.Generator)
-
-
-Generates QR Codes from text strings and byte arrays.
-
-This project aims to be the best, clearest QR Code generator library. The primary goals are flexible options
+This project aims to be the best, clearest QR code generator library. The primary goals are flexible options
 and absolute correctness. Secondary goals are compact implementation size and good documentation comments.
+
+This .NET version is built for .NET Standard 2.0 and therefore runs on most modern .NET platforms (.NET Core, .NET Framework, Mono etc.).
 
 Home page with live JavaScript demo, extensive descriptions, and competitor comparisons:
 [https://www.nayuki.io/page/qr-code-generator-library](https://www.nayuki.io/page/qr-code-generator-library)
+
+
+## .NET API Documention
+
+* [QrCode](xref:IO.Nayuki.QrCodeGen.QrCode): Creates and represents QR codes
+
+* [QrSegment](xref:IO.Nayuki.QrCodeGen.QrSegment): Represents a segment of character/binary/control data in a QR code symbol
+
+* [QrSegmentAdvanced](xref:IO.Nayuki.QrCodeGen.QrSegmentAdvanced): Advanced methods for encoding QR codes using Kanji mode or using multiple segments with different encodings.
+
+* [All types and classes](xref:IO.Nayuki.QrCodeGen)
+
 
 ## Features
 
 Core features:
 
- * Available in 7 programming languages, all with nearly equal functionality: Java, JavaScript, TypeScript, Python, C++, C, Rust
+ * Available in 8 programming languages, all with nearly equal functionality: C#, Java, JavaScript, TypeScript, Python, C++, C, Rust
 
  * Significantly shorter code but more documentation comments compared to competing libraries
 
  * Supports encoding all 40 versions (sizes) and all 4 error correction levels, as per the QR Code Model 2 standard
 
- * Output formats: Raw modules/pixels of the QR symbol, SVG XML string, {@code BufferedImage} raster bitmap
+ * Output formats: Raw modules/pixels of the QR symbol, SVG XML string, raster bitmap
 
  * Encodes numeric and special-alphanumeric text in less space than general text
 
@@ -53,40 +56,59 @@ Optional advanced features:
 
  * Computes optimal segment mode switching for text with mixed numeric/alphanumeric/general/kanji parts
 
+
 ## Examples
 
 Simple operation:
 
-```csharp
-namespace QrCode {
+```cslang
+using IO.Nayuki.QrCodeGen;
 
+namespace Examples
+{
+    class SimpleOperation
+    {
+        static void Main(string[] args)
+        {
+            var qr = QrCode.EncodeText("Hello, world!", QrCode.Ecc.Medium);
+            using (var bitmap = qr.ToBitmap(4, 10))
+            {
+                bitmap.Save("qr-code.png", ImageFormat.Png);
+            }
+        }
+    }
 }
- * <pre style="margin-left:2em">import java.awt.image.BufferedImage;
- *import java.io.File;
- *import javax.imageio.ImageIO;
- *import io.nayuki.qrcodegen.*;
- *
- *QrCode qr = QrCode.encodeText("Hello, world!", QrCode.Ecc.MEDIUM);
- *BufferedImage img = qr.toImage(4, 10);
- *ImageIO.write(img, "png", new File("qr-code.png"));</pre>
- * <p>Manual operation:</p>
- * <pre style="margin-left:2em">import java.util.List;
- *import io.nayuki.qrcodegen.*;
- *
- *List&lt;QrSegment&gt; segs = QrSegment.makeSegments("3141592653589793238462643383");
- *QrCode qr = QrCode.encodeSegments(segs, QrCode.Ecc.HIGH, 5, 5, 2, false);
- *for (int y = 0; y &lt; qr.size; y++) {
- *    for (int x = 0; x &lt; qr.size; x++) {
- *        (... paint qr.getModule(x, y) ...)
- *    }
- *}</pre>
- ```
+```
 
+Manual operation:
+
+```cslang
+using IO.Nayuki.QrCodeGen;
+
+namespace Examples
+{
+    class ManualOperation
+    {
+        static void Main(string[] args)
+        {
+            var segments = QrCode.MakeSegments("3141592653589793238462643383");
+            var qr = QrCode.EncodeSegments(segments, QrCode.Ecc.High, 5, 5, 2, false);
+            for (int y = 0; y < qr.Size; y++)
+            {
+                for (int x = 0; x < qr.Size; x++)
+                {
+                    ... paint qr.GetModule(x,y) ...
+                }
+            }
+        }
+    }
+}
+```
 
 
 ## Requirements
 
-Swiss QR Bill for .NET requires .NET Standard 2.0 or higher, i.e. any of:
+QR code generator library for .NET requires .NET Standard 2.0 or higher, i.e. any of:
 
 - .NET Core 2.0 or higher
 - .NET Framework 4.6.1 or higher

--- a/dotnet/QrCodeGenerator/docfx/api/index.md
+++ b/dotnet/QrCodeGenerator/docfx/api/index.md
@@ -1,0 +1,95 @@
+# Swiss QR Bill for .NET Reference Documentation
+
+## Reference Documentation
+
+**[Codecrete.SwissQRBill.Generator.QRBill](xref:Codecrete.SwissQRBill.Generator.QRBill)**: Generates Swiss QR bill (receipt and payment part). Also validates the bill data and encode and decode the text embedded in the QR code.
+
+**[Codecrete.SwissQRBill.Generator.QRBill](xref:Codecrete.SwissQRBill.Generator.Bill)**: QR bill data as input for generation or output from decoding
+
+**[Codecrete.SwissQRBill.Generator.Payments](xref:Codecrete.SwissQRBill.Generator.Payments)**: Utility for generating and validation payment related data such as IBAN and reference numbers.
+
+[All types and classes](xref:Codecrete.SwissQRBill.Generator)
+
+
+Generates QR Codes from text strings and byte arrays.
+
+This project aims to be the best, clearest QR Code generator library. The primary goals are flexible options
+and absolute correctness. Secondary goals are compact implementation size and good documentation comments.
+
+Home page with live JavaScript demo, extensive descriptions, and competitor comparisons:
+[https://www.nayuki.io/page/qr-code-generator-library](https://www.nayuki.io/page/qr-code-generator-library)
+
+## Features
+
+Core features:
+
+ * Available in 7 programming languages, all with nearly equal functionality: Java, JavaScript, TypeScript, Python, C++, C, Rust
+
+ * Significantly shorter code but more documentation comments compared to competing libraries
+
+ * Supports encoding all 40 versions (sizes) and all 4 error correction levels, as per the QR Code Model 2 standard
+
+ * Output formats: Raw modules/pixels of the QR symbol, SVG XML string, {@code BufferedImage} raster bitmap
+
+ * Encodes numeric and special-alphanumeric text in less space than general text
+
+ * Open source code under the permissive MIT License
+
+
+Manual parameters:
+
+ * User can specify minimum and maximum version numbers allowed, then library will automatically choose smallest version in the range that fits the data
+ 
+ * User can specify mask pattern manually, otherwise library will automatically evaluate all 8 masks and select the optimal one
+
+ * User can specify absolute error correction level, or allow the library to boost it if it doesn't increase the version number
+
+ * User can create a list of data segments manually and add ECI segments
+
+
+Optional advanced features:
+
+ * Encodes Japanese Unicode text in kanji mode to save a lot of space compared to UTF-8 bytes
+
+ * Computes optimal segment mode switching for text with mixed numeric/alphanumeric/general/kanji parts
+
+## Examples
+
+Simple operation:
+
+```csharp
+namespace QrCode {
+
+}
+ * <pre style="margin-left:2em">import java.awt.image.BufferedImage;
+ *import java.io.File;
+ *import javax.imageio.ImageIO;
+ *import io.nayuki.qrcodegen.*;
+ *
+ *QrCode qr = QrCode.encodeText("Hello, world!", QrCode.Ecc.MEDIUM);
+ *BufferedImage img = qr.toImage(4, 10);
+ *ImageIO.write(img, "png", new File("qr-code.png"));</pre>
+ * <p>Manual operation:</p>
+ * <pre style="margin-left:2em">import java.util.List;
+ *import io.nayuki.qrcodegen.*;
+ *
+ *List&lt;QrSegment&gt; segs = QrSegment.makeSegments("3141592653589793238462643383");
+ *QrCode qr = QrCode.encodeSegments(segs, QrCode.Ecc.HIGH, 5, 5, 2, false);
+ *for (int y = 0; y &lt; qr.size; y++) {
+ *    for (int x = 0; x &lt; qr.size; x++) {
+ *        (... paint qr.getModule(x, y) ...)
+ *    }
+ *}</pre>
+ ```
+
+
+
+## Requirements
+
+Swiss QR Bill for .NET requires .NET Standard 2.0 or higher, i.e. any of:
+
+- .NET Core 2.0 or higher
+- .NET Framework 4.6.1 or higher
+- Mono 5.4 or higher
+- Universal Windows Platform 10.0.16299 or higher
+- Xamarin

--- a/dotnet/QrCodeGenerator/docfx/docfx.json
+++ b/dotnet/QrCodeGenerator/docfx/docfx.json
@@ -1,0 +1,58 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "**.csproj"
+          ],
+          "src": ".."
+        }
+      ],
+      "dest": "../obj/docfx/api",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "api/**.yml"
+        ],
+        "src": "../obj/docfx"
+      },
+      {
+        "files": [
+          "index.md",
+          "api/index.md"
+        ]
+      }
+    ],
+    "resource": [
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "bin/**"
+        ]
+      }
+    ],
+    "dest": "../bin/_site",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}

--- a/dotnet/QrCodeGenerator/docfx/index.md
+++ b/dotnet/QrCodeGenerator/docfx/index.md
@@ -1,5 +1,3 @@
 # QR Code generator library for .NET
 
-## .NET API Documention
-
-[Swiss QR Bill .NET Reference Documentation](api/index.md)
+[.NET Reference Documentation](api/index.md)

--- a/dotnet/QrCodeGenerator/docfx/index.md
+++ b/dotnet/QrCodeGenerator/docfx/index.md
@@ -1,0 +1,5 @@
+# QR Code generator library for .NET
+
+## .NET API Documention
+
+[Swiss QR Bill .NET Reference Documentation](api/index.md)

--- a/dotnet/QrCodeGeneratorDemo/Program.cs
+++ b/dotnet/QrCodeGeneratorDemo/Program.cs
@@ -38,144 +38,136 @@ namespace Io.Nayuki.QrCodeGen.Demo
             DoSegmentDemo();
             DoMaskDemo();
         }
-        	
-	
-	/*---- Demo suite ----*/
-	
-	// Creates a single QR Code, then writes it to a PNG file and an SVG file.
-    private static void DoBasicDemo()
-    {
-        const string text = "Hello, world!";                         // User-supplied Unicode text
-        QrCode.Ecc errCorLvl = QrCode.Ecc.Low;                       // Error correction level
 
-        var qr = QrCode.EncodeText(text, errCorLvl);                 // Make the QR Code symbol
 
-        using (var img = qr.ToBitmap(10, 4))                         // Convert to bitmap image
+        #region Demo suite
+	    
+	    // Creates a single QR Code, then writes it to a PNG file and an SVG file.
+        private static void DoBasicDemo()
         {
-            img.Save("hello-world-QR.png", ImageFormat.Png);         // Write image to file
+            const string text = "Hello, world!"; // User-supplied Unicode text
+            var errCorLvl = QrCode.Ecc.Low; // Error correction level
+
+            var qr = QrCode.EncodeText(text, errCorLvl); // Make the QR Code symbol
+
+            using (var img = qr.ToBitmap(10, 4)) // Convert to bitmap image
+            {
+                img.Save("hello-world-QR.png", ImageFormat.Png); // Write image to file
+            }
+
+            string svg = qr.ToSvgString(4); // Convert to SVG XML code
+            File.WriteAllText("hello-world-QR.svg", svg, Encoding.UTF8); // Write image to file
         }
 
-        string svg = qr.ToSvgString(4);                              // Convert to SVG XML code
-        File.WriteAllText("hello-world-QR.svg", svg, Encoding.UTF8); // Write image to file
-    }
 
-
-    // Creates a variety of QR Codes that exercise different features of the library, and writes each one to file.
-	private static void DoVarietyDemo() {
-		QrCode qr;
-		
-		// Numeric mode encoding (3.33 bits per digit)
-		qr = QrCode.EncodeText("314159265358979323846264338327950288419716939937510", QrCode.Ecc.Medium);
-		SaveAsPng(qr, "pi-digits-QR.png", 13, 1);
-		
-		// Alphanumeric mode encoding (5.5 bits per character)
-		qr = QrCode.EncodeText("DOLLAR-AMOUNT:$39.87 PERCENTAGE:100.00% OPERATIONS:+-*/", QrCode.Ecc.High);
-		SaveAsPng(qr, "alphanumeric-QR.png", 10, 2);
-		
-		// Unicode text as UTF-8
-		qr = QrCode.EncodeText("こんにちwa、世界！ αβγδ", QrCode.Ecc.Quartile);
-		SaveAsPng(qr, "unicode-QR.png", 10, 3);
-		
-		// Moderately large QR Code using longer text (from Lewis Carroll's Alice in Wonderland)
-		qr = QrCode.EncodeText(
-			"Alice was beginning to get very tired of sitting by her sister on the bank, "
-			+ "and of having nothing to do: once or twice she had peeped into the book her sister was reading, "
-			+ "but it had no pictures or conversations in it, 'and what is the use of a book,' thought Alice "
-			+ "'without pictures or conversations?' So she was considering in her own mind (as well as she could, "
-			+ "for the hot day made her feel very sleepy and stupid), whether the pleasure of making a "
-			+ "daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly "
-			+ "a White Rabbit with pink eyes ran close by her.", QrCode.Ecc.High);
-		SaveAsPng(qr, "alice-wonderland-QR.png", 6, 10);
-	}
-	
-	
-	// Creates QR Codes with manually specified segments for better compactness.
-    private static void DoSegmentDemo()
-    {
-        QrCode qr;
-        List<QrSegment> segs;
-
-        // Illustration "silver"
-        var silver0 = "THE SQUARE ROOT OF 2 IS 1.";
-        var silver1 = "41421356237309504880168872420969807856967187537694807317667973799";
-        qr = QrCode.EncodeText(silver0 + silver1, QrCode.Ecc.Low);
-        SaveAsPng(qr, "sqrt2-monolithic-QR.png", 10, 3);
-
-        segs = new List<QrSegment>
+        // Creates a variety of QR Codes that exercise different features of the library, and writes each one to file.
+	    private static void DoVarietyDemo() {
+            // Numeric mode encoding (3.33 bits per digit)
+		    var qr = QrCode.EncodeText("314159265358979323846264338327950288419716939937510", QrCode.Ecc.Medium);
+		    SaveAsPng(qr, "pi-digits-QR.png", 13, 1);
+		    
+		    // Alphanumeric mode encoding (5.5 bits per character)
+		    qr = QrCode.EncodeText("DOLLAR-AMOUNT:$39.87 PERCENTAGE:100.00% OPERATIONS:+-*/", QrCode.Ecc.High);
+		    SaveAsPng(qr, "alphanumeric-QR.png", 10, 2);
+		    
+		    // Unicode text as UTF-8
+		    qr = QrCode.EncodeText("こんにちwa、世界！ αβγδ", QrCode.Ecc.Quartile);
+		    SaveAsPng(qr, "unicode-QR.png", 10, 3);
+		    
+		    // Moderately large QR Code using longer text (from Lewis Carroll's Alice in Wonderland)
+		    qr = QrCode.EncodeText(
+			    "Alice was beginning to get very tired of sitting by her sister on the bank, "
+			    + "and of having nothing to do: once or twice she had peeped into the book her sister was reading, "
+			    + "but it had no pictures or conversations in it, 'and what is the use of a book,' thought Alice "
+			    + "'without pictures or conversations?' So she was considering in her own mind (as well as she could, "
+			    + "for the hot day made her feel very sleepy and stupid), whether the pleasure of making a "
+			    + "daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly "
+			    + "a White Rabbit with pink eyes ran close by her.", QrCode.Ecc.High);
+		    SaveAsPng(qr, "alice-wonderland-QR.png", 6, 10);
+	    }
+	    
+	    
+	    // Creates QR Codes with manually specified segments for better compactness.
+        private static void DoSegmentDemo()
         {
-            QrSegment.MakeAlphanumeric(silver0),
-            QrSegment.MakeNumeric(silver1)
-        };
-        qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
-        SaveAsPng(qr, "sqrt2-segmented-QR.png", 10, 3);
+            // Illustration "silver"
+            const string silver0 = "THE SQUARE ROOT OF 2 IS 1.";
+            const string silver1 = "41421356237309504880168872420969807856967187537694807317667973799";
+            var qr = QrCode.EncodeText(silver0 + silver1, QrCode.Ecc.Low);
+            SaveAsPng(qr, "sqrt2-monolithic-QR.png", 10, 3);
 
-        // Illustration "golden"
-        string golden0 = "Golden ratio φ = 1.";
-        string golden1 =
-            "6180339887498948482045868343656381177203091798057628621354486227052604628189024497072072041893911374";
-        string golden2 = "......";
-        qr = QrCode.EncodeText(golden0 + golden1 + golden2, QrCode.Ecc.Low);
-        SaveAsPng(qr, "phi-monolithic-QR.png", 8, 5);
+            var segs = new List<QrSegment>
+            {
+                QrSegment.MakeAlphanumeric(silver0),
+                QrSegment.MakeNumeric(silver1)
+            };
+            qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+            SaveAsPng(qr, "sqrt2-segmented-QR.png", 10, 3);
 
-        segs = new List<QrSegment>
+            // Illustration "golden"
+            const string golden0 = "Golden ratio φ = 1.";
+            const string golden1 =
+                "6180339887498948482045868343656381177203091798057628621354486227052604628189024497072072041893911374";
+            const string golden2 = "......";
+            qr = QrCode.EncodeText(golden0 + golden1 + golden2, QrCode.Ecc.Low);
+            SaveAsPng(qr, "phi-monolithic-QR.png", 8, 5);
+
+            segs = new List<QrSegment>
+            {
+                QrSegment.MakeBytes(Encoding.UTF8.GetBytes(golden0)),
+                QrSegment.MakeNumeric(golden1),
+                QrSegment.MakeAlphanumeric(golden2)
+            };
+
+            qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+		    SaveAsPng(qr, "phi-segmented-QR.png", 8, 5);
+		    
+		    // Illustration "Madoka": kanji, kana, Cyrillic, full-width Latin, Greek characters
+		    const string madoka = "「魔法少女まどか☆マギカ」って、　ИАИ　ｄｅｓｕ　κα？";
+		    qr = QrCode.EncodeText(madoka, QrCode.Ecc.Low);
+		    SaveAsPng(qr, "madoka-utf8-QR.png", 9, 4);
+
+            segs = new List<QrSegment>  { QrSegmentAdvanced.MakeKanji(madoka) };
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+		    SaveAsPng(qr, "madoka-kanji-QR.png", 9, 4);
+	    }
+	    
+	    
+	    // Creates QR Codes with the same size and contents but different mask patterns.
+	    private static void DoMaskDemo() {
+            // Project Nayuki URL
+		    var segs = QrSegment.MakeSegments("https://www.nayuki.io/");
+		    var qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, -1, true);
+		    SaveAsPng(qr, "project-nayuki-automask-QR.png", 8, 6);
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, 3, true);  // Force mask 3
+		    SaveAsPng(qr, "project-nayuki-mask3-QR.png", 8, 6);
+		    
+		    // Chinese text as UTF-8
+		    segs = QrSegment.MakeSegments("維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫");
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 0, true);  // Force mask 0
+		    SaveAsPng(qr, "unicode-mask0-QR.png", 10, 3);
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 1, true);  // Force mask 1
+		    SaveAsPng(qr, "unicode-mask1-QR.png", 10, 3);
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 5, true);  // Force mask 5
+		    SaveAsPng(qr, "unicode-mask5-QR.png", 10, 3);
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 7, true);  // Force mask 7
+		    SaveAsPng(qr, "unicode-mask7-QR.png", 10, 3);
+	    }
+
+        #endregion
+
+
+        #region Utilities
+
+        private static void SaveAsPng(QrCode qrCode, string filename, int scale, int border)
         {
-            QrSegment.MakeBytes(Encoding.UTF8.GetBytes(golden0)),
-            QrSegment.MakeNumeric(golden1),
-            QrSegment.MakeAlphanumeric(golden2)
-        };
-
-        qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
-		SaveAsPng(qr, "phi-segmented-QR.png", 8, 5);
-		
-		// Illustration "Madoka": kanji, kana, Cyrillic, full-width Latin, Greek characters
-		string madoka = "「魔法少女まどか☆マギカ」って、　ИАИ　ｄｅｓｕ　κα？";
-		qr = QrCode.EncodeText(madoka, QrCode.Ecc.Low);
-		SaveAsPng(qr, "madoka-utf8-QR.png", 9, 4);
-
-        segs = new List<QrSegment>
-        {
-            // QrSegmentAdvanced.MakeKanji(madoka)
-        };
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
-		SaveAsPng(qr, "madoka-kanji-QR.png", 9, 4);
-	}
-	
-	
-	// Creates QR Codes with the same size and contents but different mask patterns.
-	private static void DoMaskDemo() {
-		QrCode qr;
-		List<QrSegment> segs;
-		
-		// Project Nayuki URL
-		segs = QrSegment.MakeSegments("https://www.nayuki.io/");
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, -1, true);  // Automatic mask
-		SaveAsPng(qr, "project-nayuki-automask-QR.png", 8, 6);
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, 3, true);  // Force mask 3
-		SaveAsPng(qr, "project-nayuki-mask3-QR.png", 8, 6);
-		
-		// Chinese text as UTF-8
-		segs = QrSegment.MakeSegments("維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫");
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 0, true);  // Force mask 0
-		SaveAsPng(qr, "unicode-mask0-QR.png", 10, 3);
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 1, true);  // Force mask 1
-		SaveAsPng(qr, "unicode-mask1-QR.png", 10, 3);
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 5, true);  // Force mask 5
-		SaveAsPng(qr, "unicode-mask5-QR.png", 10, 3);
-		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 7, true);  // Force mask 7
-		SaveAsPng(qr, "unicode-mask7-QR.png", 10, 3);
-	}
-
-    #region Utilities
-
-    private static void SaveAsPng(QrCode qrCode, string filename, int scale, int border)
-    {
-        using (var bitmap = qrCode.ToBitmap(scale, border))
-        {
-            bitmap.Save(filename, ImageFormat.Png);
+            using (var bitmap = qrCode.ToBitmap(scale, border))
+            {
+                bitmap.Save(filename, ImageFormat.Png);
+            }
         }
-    }
 
-    #endregion
+        #endregion
 		
     }
 }

--- a/dotnet/QrCodeGeneratorDemo/Program.cs
+++ b/dotnet/QrCodeGeneratorDemo/Program.cs
@@ -1,0 +1,181 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Drawing.Imaging;
+using System.Text;
+
+namespace Io.Nayuki.QrCodeGen.Demo
+{
+    internal class Program
+    {
+        // The main application program.
+        internal static void Main(string[] args)
+        {
+            DoBasicDemo();
+            DoVarietyDemo();
+            DoSegmentDemo();
+            DoMaskDemo();
+        }
+        	
+	
+	/*---- Demo suite ----*/
+	
+	// Creates a single QR Code, then writes it to a PNG file and an SVG file.
+    private static void DoBasicDemo()
+    {
+        const string text = "Hello, world!";                         // User-supplied Unicode text
+        QrCode.Ecc errCorLvl = QrCode.Ecc.Low;                       // Error correction level
+
+        var qr = QrCode.EncodeText(text, errCorLvl);                 // Make the QR Code symbol
+
+        using (var img = qr.ToBitmap(10, 4))                         // Convert to bitmap image
+        {
+            img.Save("hello-world-QR.png", ImageFormat.Png);         // Write image to file
+        }
+
+        string svg = qr.ToSvgString(4);                              // Convert to SVG XML code
+        File.WriteAllText("hello-world-QR.svg", svg, Encoding.UTF8); // Write image to file
+    }
+
+
+    // Creates a variety of QR Codes that exercise different features of the library, and writes each one to file.
+	private static void DoVarietyDemo() {
+		QrCode qr;
+		
+		// Numeric mode encoding (3.33 bits per digit)
+		qr = QrCode.EncodeText("314159265358979323846264338327950288419716939937510", QrCode.Ecc.Medium);
+		SaveAsPng(qr, "pi-digits-QR.png", 13, 1);
+		
+		// Alphanumeric mode encoding (5.5 bits per character)
+		qr = QrCode.EncodeText("DOLLAR-AMOUNT:$39.87 PERCENTAGE:100.00% OPERATIONS:+-*/", QrCode.Ecc.High);
+		SaveAsPng(qr, "alphanumeric-QR.png", 10, 2);
+		
+		// Unicode text as UTF-8
+		qr = QrCode.EncodeText("こんにちwa、世界！ αβγδ", QrCode.Ecc.Quartile);
+		SaveAsPng(qr, "unicode-QR.png", 10, 3);
+		
+		// Moderately large QR Code using longer text (from Lewis Carroll's Alice in Wonderland)
+		qr = QrCode.EncodeText(
+			"Alice was beginning to get very tired of sitting by her sister on the bank, "
+			+ "and of having nothing to do: once or twice she had peeped into the book her sister was reading, "
+			+ "but it had no pictures or conversations in it, 'and what is the use of a book,' thought Alice "
+			+ "'without pictures or conversations?' So she was considering in her own mind (as well as she could, "
+			+ "for the hot day made her feel very sleepy and stupid), whether the pleasure of making a "
+			+ "daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly "
+			+ "a White Rabbit with pink eyes ran close by her.", QrCode.Ecc.High);
+		SaveAsPng(qr, "alice-wonderland-QR.png", 6, 10);
+	}
+	
+	
+	// Creates QR Codes with manually specified segments for better compactness.
+    private static void DoSegmentDemo()
+    {
+        QrCode qr;
+        List<QrSegment> segs;
+
+        // Illustration "silver"
+        var silver0 = "THE SQUARE ROOT OF 2 IS 1.";
+        var silver1 = "41421356237309504880168872420969807856967187537694807317667973799";
+        qr = QrCode.EncodeText(silver0 + silver1, QrCode.Ecc.Low);
+        SaveAsPng(qr, "sqrt2-monolithic-QR.png", 10, 3);
+
+        segs = new List<QrSegment>
+        {
+            QrSegment.MakeAlphanumeric(silver0),
+            QrSegment.MakeNumeric(silver1)
+        };
+        qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+        SaveAsPng(qr, "sqrt2-segmented-QR.png", 10, 3);
+
+        // Illustration "golden"
+        string golden0 = "Golden ratio φ = 1.";
+        string golden1 =
+            "6180339887498948482045868343656381177203091798057628621354486227052604628189024497072072041893911374";
+        string golden2 = "......";
+        qr = QrCode.EncodeText(golden0 + golden1 + golden2, QrCode.Ecc.Low);
+        SaveAsPng(qr, "phi-monolithic-QR.png", 8, 5);
+
+        segs = new List<QrSegment>
+        {
+            QrSegment.MakeBytes(Encoding.UTF8.GetBytes(golden0)),
+            QrSegment.MakeNumeric(golden1),
+            QrSegment.MakeAlphanumeric(golden2)
+        };
+
+        qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+		SaveAsPng(qr, "phi-segmented-QR.png", 8, 5);
+		
+		// Illustration "Madoka": kanji, kana, Cyrillic, full-width Latin, Greek characters
+		string madoka = "「魔法少女まどか☆マギカ」って、　ИАИ　ｄｅｓｕ　κα？";
+		qr = QrCode.EncodeText(madoka, QrCode.Ecc.Low);
+		SaveAsPng(qr, "madoka-utf8-QR.png", 9, 4);
+
+        segs = new List<QrSegment>
+        {
+            // QrSegmentAdvanced.MakeKanji(madoka)
+        };
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Low);
+		SaveAsPng(qr, "madoka-kanji-QR.png", 9, 4);
+	}
+	
+	
+	// Creates QR Codes with the same size and contents but different mask patterns.
+	private static void DoMaskDemo() {
+		QrCode qr;
+		List<QrSegment> segs;
+		
+		// Project Nayuki URL
+		segs = QrSegment.MakeSegments("https://www.nayuki.io/");
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, -1, true);  // Automatic mask
+		SaveAsPng(qr, "project-nayuki-automask-QR.png", 8, 6);
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, 3, true);  // Force mask 3
+		SaveAsPng(qr, "project-nayuki-mask3-QR.png", 8, 6);
+		
+		// Chinese text as UTF-8
+		segs = QrSegment.MakeSegments("維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫");
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 0, true);  // Force mask 0
+		SaveAsPng(qr, "unicode-mask0-QR.png", 10, 3);
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 1, true);  // Force mask 1
+		SaveAsPng(qr, "unicode-mask1-QR.png", 10, 3);
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 5, true);  // Force mask 5
+		SaveAsPng(qr, "unicode-mask5-QR.png", 10, 3);
+		qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 7, true);  // Force mask 7
+		SaveAsPng(qr, "unicode-mask7-QR.png", 10, 3);
+	}
+
+    #region Utilities
+
+    private static void SaveAsPng(QrCode qrCode, string filename, int scale, int border)
+    {
+        using (var bitmap = qrCode.ToBitmap(scale, border))
+        {
+            bitmap.Save(filename, ImageFormat.Png);
+        }
+    }
+
+    #endregion
+		
+    }
+}

--- a/dotnet/QrCodeGeneratorDemo/Program.cs
+++ b/dotnet/QrCodeGeneratorDemo/Program.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -42,13 +42,13 @@ namespace IO.Nayuki.QrCodeGen.Demo
 
         #region Demo suite
 	    
-	    // Creates a single QR Code, then writes it to a PNG file and an SVG file.
+	    // Creates a single QR code, then writes it to a PNG file and an SVG file.
         private static void DoBasicDemo()
         {
             const string text = "Hello, world!"; // User-supplied Unicode text
             var errCorLvl = QrCode.Ecc.Low; // Error correction level
 
-            var qr = QrCode.EncodeText(text, errCorLvl); // Make the QR Code symbol
+            var qr = QrCode.EncodeText(text, errCorLvl); // Make the QR code symbol
 
             using (var img = qr.ToBitmap(10, 4)) // Convert to bitmap image
             {
@@ -60,7 +60,7 @@ namespace IO.Nayuki.QrCodeGen.Demo
         }
 
 
-        // Creates a variety of QR Codes that exercise different features of the library, and writes each one to file.
+        // Creates a variety of QR codes that exercise different features of the library, and writes each one to file.
 	    private static void DoVarietyDemo() {
             // Numeric mode encoding (3.33 bits per digit)
 		    var qr = QrCode.EncodeText("314159265358979323846264338327950288419716939937510", QrCode.Ecc.Medium);
@@ -74,7 +74,7 @@ namespace IO.Nayuki.QrCodeGen.Demo
 		    qr = QrCode.EncodeText("こんにちwa、世界！ αβγδ", QrCode.Ecc.Quartile);
 		    SaveAsPng(qr, "unicode-QR.png", 10, 3);
 		    
-		    // Moderately large QR Code using longer text (from Lewis Carroll's Alice in Wonderland)
+		    // Moderately large QR code using longer text (from Lewis Carroll's Alice in Wonderland)
 		    qr = QrCode.EncodeText(
 			    "Alice was beginning to get very tired of sitting by her sister on the bank, "
 			    + "and of having nothing to do: once or twice she had peeped into the book her sister was reading, "
@@ -87,7 +87,7 @@ namespace IO.Nayuki.QrCodeGen.Demo
 	    }
 	    
 	    
-	    // Creates QR Codes with manually specified segments for better compactness.
+	    // Creates QR codes with manually specified segments for better compactness.
         private static void DoSegmentDemo()
         {
             // Illustration "silver"
@@ -133,24 +133,24 @@ namespace IO.Nayuki.QrCodeGen.Demo
 	    }
 	    
 	    
-	    // Creates QR Codes with the same size and contents but different mask patterns.
+	    // Creates QR codes with the same size and contents but different mask patterns.
 	    private static void DoMaskDemo() {
             // Project Nayuki URL
 		    var segs = QrSegment.MakeSegments("https://www.nayuki.io/");
-		    var qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, -1, true);
+		    var qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High);
 		    SaveAsPng(qr, "project-nayuki-automask-QR.png", 8, 6);
-		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, 3, true);  // Force mask 3
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.High, QrCode.MinVersion, QrCode.MaxVersion, 3);  // Force mask 3
 		    SaveAsPng(qr, "project-nayuki-mask3-QR.png", 8, 6);
 		    
 		    // Chinese text as UTF-8
 		    segs = QrSegment.MakeSegments("維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫");
-		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 0, true);  // Force mask 0
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 0);  // Force mask 0
 		    SaveAsPng(qr, "unicode-mask0-QR.png", 10, 3);
-		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 1, true);  // Force mask 1
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 1);  // Force mask 1
 		    SaveAsPng(qr, "unicode-mask1-QR.png", 10, 3);
-		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 5, true);  // Force mask 5
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 5);  // Force mask 5
 		    SaveAsPng(qr, "unicode-mask5-QR.png", 10, 3);
-		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 7, true);  // Force mask 7
+		    qr = QrCode.EncodeSegments(segs, QrCode.Ecc.Medium, QrCode.MinVersion, QrCode.MaxVersion, 7);  // Force mask 7
 		    SaveAsPng(qr, "unicode-mask7-QR.png", 10, 3);
 	    }
 

--- a/dotnet/QrCodeGeneratorDemo/Program.cs
+++ b/dotnet/QrCodeGeneratorDemo/Program.cs
@@ -26,7 +26,7 @@ using System.IO;
 using System.Drawing.Imaging;
 using System.Text;
 
-namespace Io.Nayuki.QrCodeGen.Demo
+namespace IO.Nayuki.QrCodeGen.Demo
 {
     internal class Program
     {

--- a/dotnet/QrCodeGeneratorDemo/QrCodeGeneratorDemo.csproj
+++ b/dotnet/QrCodeGeneratorDemo/QrCodeGeneratorDemo.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>Io.Nayuki.QrCodeGen.Demo</RootNamespace>
+    <PackageId>Io.Nayuki.QrCodeGen.Demo</PackageId>
+    <Version>1.4.1</Version>
+    <Authors>Project Nayuki</Authors>
+    <Product>QR Code Generator for .NET</Product>
+    <Description>Demo application for QR Code Generation</Description>
+    <Copyright>Copyright (c) Project Nayuki. (MIT License)</Copyright>
+    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageProjectUrl>https://www.nayuki.io/page/qr-code-generator-library</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/nayuki/QR-Code-generator</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QrCodeGenerator\QrCodeGenerator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/QrCodeGeneratorDemo/QrCodeGeneratorDemo.csproj
+++ b/dotnet/QrCodeGeneratorDemo/QrCodeGeneratorDemo.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <RootNamespace>Io.Nayuki.QrCodeGen.Demo</RootNamespace>
-    <PackageId>Io.Nayuki.QrCodeGen.Demo</PackageId>
+    <RootNamespace>IO.Nayuki.QrCodeGen.Demo</RootNamespace>
+    <PackageId>IO.Nayuki.QrCodeGen.Demo</PackageId>
     <Version>1.4.1</Version>
     <Authors>Project Nayuki</Authors>
     <Product>QR Code Generator for .NET</Product>

--- a/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
+++ b/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
+++ b/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
@@ -1,0 +1,79 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System;
+using System.Collections;
+using Xunit;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class BitArrayExtensionsTest
+    {
+        [Fact]
+        private void AppendInt1()
+        {
+            var ba = new BitArray(0);
+            ba.AppendBits(18, 6);
+
+            Assert.Equal(6, ba.Length);
+
+            Assert.False(ba[0]);
+            Assert.True(ba[1]);
+            Assert.False(ba[2]);
+            Assert.False(ba[3]);
+            Assert.True(ba[4]);
+            Assert.False(ba[5]);
+        }
+
+        [Fact]
+        private void AppendInt2()
+        {
+            var ba = new BitArray(0);
+            ba.AppendBits(18, 6);
+
+            ba.AppendBits(3, 2);
+
+            Assert.Equal(8, ba.Length);
+
+            Assert.False(ba[0]);
+            Assert.True(ba[1]);
+            Assert.False(ba[2]);
+            Assert.False(ba[3]);
+            Assert.True(ba[4]);
+            Assert.False(ba[5]);
+            Assert.True(ba[6]);
+            Assert.True(ba[7]);
+        }
+
+        [Fact]
+        private void AppendExtraBits()
+        {
+            var ba = new BitArray(0);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                ba.AppendBits(128, 4);
+            });
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
+++ b/dotnet/QrCodeGeneratorTest/BitArrayExtensionsTest.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections;
 using Xunit;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class BitArrayExtensionsTest
     {

--- a/dotnet/QrCodeGeneratorTest/KanjiTest.cs
+++ b/dotnet/QrCodeGeneratorTest/KanjiTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/KanjiTest.cs
+++ b/dotnet/QrCodeGeneratorTest/KanjiTest.cs
@@ -24,7 +24,7 @@
 using System.Collections.Generic;
 using Xunit;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class KanjiTest
     {

--- a/dotnet/QrCodeGeneratorTest/KanjiTest.cs
+++ b/dotnet/QrCodeGeneratorTest/KanjiTest.cs
@@ -1,0 +1,93 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class KanjiTest
+    {
+        private const string KanjiSample
+            = "委マツニオ男喜でろつ絶選にッ自君エ碁４配堪イルネコ禁２京果ユウタカ著書ンぴは役村ン政経購税き視思６１近退ほぜ。投むでみ書権し輔組キ黒壁えちをあ刊中申内イヌ著太記ヲ庁宿ホマ湯連マクラ相就づ藤業トリカ場止ラマエニ現露ラ情伝ま登厘架れち。任ムオホ除８５郊ツ執父たはんゅ喜離レクセサ社暖せげ磨育こぽずぎ聞来ンは事聞煙や無杯すやべぽ信９３幕もいび及町いば事階齢利江ず。"
+              + "陸スシネク賢軽ワマ産闘人めせ視豊ネワマキ庭朝療へ終胸ずでリぐ価交こる覧夜でわみを氷性聞年よとク。朝定掲ぞぴえる縄策ヌキウク主力まひ本生ウヒア鎖検ヘ同階リぞ美字ツイキニ問企表カクツ助１台づレぼえ。事箕ケテ内上べが訃長す容批ヨ多帯ヌムフハ社早オイ球選アヘ話交じぞぽ上国７８覚は根辺むげたょ室也も。"
+              + "数ヨフヱイ血結質ッろ護外すうだご古犠リ自陽カアタ幅交数ぼもそき請件ろ問拉著フヒミ陰天６１債ン。竹ごつべク市成キヤウ検新スセヒヲ花期的もぴは嶋信ヱマサワ局記来イヲナネ比引フタニハ津適よいうり長熊う割監ッそ投出リラツル誇載距ふかすん論紅ょごくむ井５消宗征訟おなス。油ヤレワ減力テミ機４６残ツケ遺鳥そ前名ニ作３８草あぶづだ見遠ヘ覧程ラり転由教おとへ当潟とみ味購域施活ぜどだ。"
+              + "駆投ねづ女日べリりが離口にわ神新え続竹ワハ時円とりば権読け質打ノセ記囲ラヨヒソ暮交だ族時加せげ。山テカ牧於ちぶん社４７開低きねぽぶ眼明んドっ東検キ連可劇はよしぶ意田ソ信道ユヌネル経自い日花ぴラに。休ク況術ハヤ感要ヨ禁社ぴくざな賠表台里レヱ属自ホヱ民活え因物ぴぽド形型会ロモヱセ法本談ル関４９打ツノ速新ぎき堀冬密浦絶どぞつ。"
+              + "追ろ役陸モヘセ担妊ぱゅン島４７自ミリシホ子載科ぐばのド返物ナ月営わを屋界ヒクエム取強あるゆ売増ロムネ鶏交応更ょ。認投か者木ッ変甲テケツマ類読けっイり鋼巻ス観市徴ンぎる金谷ゆけ当披トソロ薬身とを勢米ハ件確ー実市浮絵レ。職ウト基交と止士高こてゆべ集団制ラクイ観経回スミネカ治６聖うぜ頑機ずお国２０覧歌ヌレ故携ムネナシ選文ヲレ西納３０図ねリず行格ぜお電医丸族の。"
+              + "県梨フアヨ長気チ手過フエ本患イやぼ回劇ぶ表神サヘヌ聞変モチ導産埼もすけん付必ッ罪真え号情６長ドンたじ雄員将格真復ほるおと。答モ闘貨午マソカチ革覇ヱキチマ農多ルメタ宮門ルメユ中作ツキテ主書タカモサ事崎ぞルぼ犯柴海図ほち義暴よッろン阪制エ景修級ぐル。変ム注止まどけふ境趣んかラ内経むがる面２８湯ぱはげど元使ナ屋俸どだび会表連トスなり年埋たれゃ。"
+              + "資むぎ方退キソセ逃於ケイヲカ域元まど月経快美りか再入ソエヨム播大マス勝星むま芸投フサル男記クかふば詰当ソ患京へ駆食えぞ知属ヱレアユ市秋ょ。７速コ覧広ヤミチケ接済なクろ件２段ト折６７的了だぞじ伸属ぴっ秋頭イナタフ聞践周は上並あ一６便苦レざ外喰杜椿榎び。応めにえン稿業タキリ盗１６水春めわ雑成めす国含ウレハラ最完レ面立更東稿ハクヌ添起チタヨテ営尾ら。"
+              + "済メヌ集取ネツホユ人９芋ヒツコワ春３４能メレタツ朝源ぞ名校げイ太化テソタ近慎ナ口２０夜け会報あルトお量問保ぎ場上っ浪足まだゅト育更ラホテカ太健象延ゆル。展つゃた後幸ちぞわぼ金質レ未曲ネマ勝投の若著遅ごぽ時顔セカ報高夫コユエラ応迎飯りばまで愛児ケ息９債核築がち。応文ドッ記強ユノヌエ初検なしよぱ長止表へよ今工テメ相取載ミ青１書にあひ略稿ぶごよ的会報じぐ挑政手一基づ。"
+              + "覧ツハ女子み絡康８９嘉塁塾嶋４分４約タニウ政提タヌル王朝よきはべ運案ヒホ男週めーお開培イわ北事巡流む。服勢ラメリユ邦大め地若ゅ構神ヒカロ疑育サ済供しりろべ告惑合コヤリナ代井てじぜゆ沖立験ヲモスロ加知ネ競３０嘉塁塾嶋９０女れフわず勝脱せでに植出党尾滋ず。写ねけを値碁ヌロ計新そへう最男イ筑地ー作提ツムハウ暮工ざ転阜終ふてお抑売買エ題要じレ王護い手乗学カクリソ発府めだごラ変実三以て。"
+              + "世なべるそ名走スレヤ変週トウ残予ハサヌカ払者じのドル分定リば米６１与アエユ来熱成かのら終参しつド日備てな要勤奇そむ磐価ヌ問者チ治本ンむくい限前サトスハ郎禁ヘマ自朝せ主並局行承ね。全キロヲ芸来はてし見９所謙レ撤住ワ約子情農スニ手個いよゆぴ事断ニ遊８３常左県煙８東金締ばねぞ。友府ょ盤養虚ぽ昇球つはー繰申チオ境著ごふょ派広だ戦事すめ無問きこどぱ毎保３７火ヱト韓端侍勃卑ぼン。";
+
+        [Fact]
+        private void IsKanjiEncodable()
+        {
+            Assert.True(QrSegmentAdvanced.IsEncodableAsKanji(KanjiSample));
+        }
+
+
+        private const string KanjiText = "昨夜のコンサートは最高でした。";
+
+        private static readonly string[] KanjiModules = {
+            "XXXXXXX  XXX   X  XXXXXXX",
+            "X     X  X X  X   X     X",
+            "X XXX X X X X     X XXX X",
+            "X XXX X X   X  XX X XXX X",
+            "X XXX X XXX X XXX X XXX X",
+            "X     X XXX   XXX X     X",
+            "XXXXXXX X X X X X XXXXXXX",
+            "        XXXX   X         ",
+            "X XXXXX  X    XX  XXXXX  ",
+            " X  X  X  XXX X XXXX XXXX",
+            "  XX XX XXXX   X  X XXX X",
+            "  XX X XXX   X    XX    X",
+            "X XX  X   X X     X  X XX",
+            "XX  X  XXX   XX X X XX  X",
+            "X     XXX XXXX X  XX XX  ",
+            "X  XX   XXXX X   X  XXXXX",
+            "X XXXXX XX XX   XXXXX  X ",
+            "        X X X  XX   XXX X",
+            "XXXXXXX  XX X XXX X XX XX",
+            "X     X X X XX XX   XX X ",
+            "X XXX X X   XXXXXXXXX  X ",
+            "X XXX X XXX   X XXX XXX X",
+            "X XXX X XXX X X    XX   X",
+            "X     X  XX X  XX X  X  X",
+            "XXXXXXX X   X  XXXX  XX  "
+        };
+
+        [Fact]
+        private void KanjiQrCode()
+        {
+            var segment = QrSegmentAdvanced.MakeKanji(KanjiText);
+            var segments = new List<QrSegment> {segment};
+            var qrCode = QrCode.EncodeSegments(segments, QrCode.Ecc.Medium);
+
+            Assert.Same(QrCode.Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(25, qrCode.Size);
+            Assert.Equal(2, qrCode.Mask);
+            Assert.Equal(KanjiModules, TestHelper.ToStringArray(qrCode));
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
+++ b/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
+++ b/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
@@ -21,10 +21,9 @@
  *   Software.
  */
 
-using System.Collections.Generic;
 using Xunit;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class OptimalSegmentTest
     {

--- a/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
+++ b/dotnet/QrCodeGeneratorTest/OptimalSegmentTest.cs
@@ -1,0 +1,77 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class OptimalSegmentTest
+    {
+        private const string Text1 = "2342342340ABC234234jkl~~";
+
+        private static readonly string[] Modules1 = {
+            "XXXXXXX XXXX XXXX   X XXXXXXX",
+            "X     X       X    XX X     X",
+            "X XXX X  X XXX  XXX X X XXX X",
+            "X XXX X XXXXX  X  XX  X XXX X",
+            "X XXX X  X XX    XX   X XXX X",
+            "X     X  X     X  X   X     X",
+            "XXXXXXX X X X X X X X XXXXXXX",
+            "         X XX XXX            ",
+            "  X XXX XX  XXX X   XX   X  X",
+            "   X    XX   X     XX X XXXXX",
+            "    XXX          X XXXX X    ",
+            "    X     X X     X XX  X XXX",
+            "XX X  XXXXX XXXXXXXXX   XXXX ",
+            "  X X    X   XX  X     X X X ",
+            "  XXXXX  XXX XXX    XX   X  X",
+            "XXXXX   XX  XX  X  XXX X XXX ",
+            "XXX   XXX  XXX     X  XX     ",
+            "        X X    XX  X X  X  X ",
+            "X X XXXX XXXX X  X   X  X X  ",
+            " X X X XX  X   X XXX X XX XXX",
+            "X  X XX  X XXX   XX XXXXXXX X",
+            "        X    X X    X   XXXX ",
+            "XXXXXXX   X  XX X XXX X X X  ",
+            "X     X X X XX X   XX   X XX ",
+            "X XXX X XXXX XX X X XXXXX    ",
+            "X XXX X  X X  X   XX  XX   X ",
+            "X XXX X X    X   XXXXXX X   X",
+            "X     X  XXX  XX X X  XXX X  ",
+            "XXXXXXX  XXXX  X  XX     XX X"
+        };
+
+        [Fact]
+        private void OptimalSegmentCode()
+        {
+            var segments = QrSegmentAdvanced.MakeSegmentsOptimally(Text1, QrCode.Ecc.High, 1, 40);
+            var qrCode = QrCode.EncodeSegments(segments, QrCode.Ecc.High);
+
+            Assert.Same(QrCode.Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(29, qrCode.Size);
+            Assert.Equal(0, qrCode.Mask);
+            Assert.Equal(Modules1, TestHelper.ToStringArray(qrCode));
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/PngTest.cs
+++ b/dotnet/QrCodeGeneratorTest/PngTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/PngTest.cs
+++ b/dotnet/QrCodeGeneratorTest/PngTest.cs
@@ -23,9 +23,9 @@
 
 using System.Drawing.Imaging;
 using Xunit;
-using static Io.Nayuki.QrCodeGen.QrCode;
+using static IO.Nayuki.QrCodeGen.QrCode;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class PngTest
     {

--- a/dotnet/QrCodeGeneratorTest/PngTest.cs
+++ b/dotnet/QrCodeGeneratorTest/PngTest.cs
@@ -1,0 +1,45 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System.Drawing.Imaging;
+using Xunit;
+using static Io.Nayuki.QrCodeGen.QrCode;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class PngTest
+    {
+        [Fact]
+        private void PngImage()
+        {
+            var qrCode = EncodeText("The quick brown fox jumps over the lazy dog", Ecc.High);
+            using (var bitmap = qrCode.ToImage(3, 4))
+            {
+                Assert.Equal(135, bitmap.Width);
+                Assert.Equal(135, bitmap.Height);
+
+                bitmap.Save("qrcode.png", ImageFormat.Png);
+            }
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
+++ b/dotnet/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>Io.Nayuki.QrCodeGen.Test</RootNamespace>
+
+    <PackageId>Io.Nayuki.QrCodeGen.Test</PackageId>
+
+    <Version>1.4.1</Version>
+
+    <Authors>Project Nayuki</Authors>
+
+    <Company>Project Nayuki</Company>
+
+    <Product>QR Code Generator for .NET</Product>
+
+    <Description>Unit tests for QR Code Generator</Description>
+
+    <Copyright>Copyright (c) Project Nayuki. (MIT License)</Copyright>
+
+    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+
+    <PackageProjectUrl>https://www.nayuki.io/page/qr-code-generator-library</PackageProjectUrl>
+
+    <RepositoryUrl>https://github.com/nayuki/QR-Code-generator</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QrCodeGenerator\QrCodeGenerator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
+++ b/dotnet/QrCodeGeneratorTest/QrCodeGeneratorTest.csproj
@@ -5,9 +5,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <RootNamespace>Io.Nayuki.QrCodeGen.Test</RootNamespace>
+    <RootNamespace>IO.Nayuki.QrCodeGen.Test</RootNamespace>
 
-    <PackageId>Io.Nayuki.QrCodeGen.Test</PackageId>
+    <PackageId>IO.Nayuki.QrCodeGen.Test</PackageId>
 
     <Version>1.4.1</Version>
 

--- a/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
@@ -23,9 +23,9 @@
 
 using System.Text;
 using Xunit;
-using static Io.Nayuki.QrCodeGen.QrCode;
+using static IO.Nayuki.QrCodeGen.QrCode;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class QrCodeTest
     {

--- a/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
@@ -1,0 +1,930 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System.Text;
+using Xunit;
+using static Io.Nayuki.QrCodeGen.QrCode;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class QrCodeTest
+    {
+
+        private static readonly string[] Modules0 = {
+            "XXXXXXX  X    XXXXXXX",
+            "X     X XX  X X     X",
+            "X XXX X     X X XXX X",
+            "X XXX X  XX X X XXX X",
+            "X XXX X  X    X XXX X",
+            "X     X XXXX  X     X",
+            "XXXXXXX X X X XXXXXXX",
+            "        X   X        ",
+            "    XXXX   XX XX   X ",
+            " X  XX  XX XXX X  X  ",
+            " XXX  XX    XXXXXXXX ",
+            "X  X X X X X X  X XX ",
+            "X   XXXX  XX         ",
+            "        X X  XX   X  ",
+            "XXXXXXX X     X  X X ",
+            "X     X XXXXXXXX X X ",
+            "X XXX X XX XXX XX XXX",
+            "X XXX X  XXXX  X X XX",
+            "X XXX X  X  X  XXXX  ",
+            "X     X    X  X X XX ",
+            "XXXXXXX  X X X    XXX"
+        };
+
+        private const string Text0 = "98323";
+
+        [Fact]
+        private void TestCode0()
+        {
+            var qrCode = EncodeText(Text0, Ecc.Medium);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(21, qrCode.Size);
+            Assert.Equal(4, qrCode.Mask);
+            Assert.Equal(Modules0, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules1 = {
+            "XXXXXXX X X XXX     X XXXXXXX",
+            "X     X X   X XXX  XX X     X",
+            "X XXX X XXXX  X   X X X XXX X",
+            "X XXX X X  XX XX  XX  X XXX X",
+            "X XXX X X      XXX X  X XXX X",
+            "X     X  X X X    XX  X     X",
+            "XXXXXXX X X X X X X X XXXXXXX",
+            "        X   XX XX  X         ",
+            " XX X XX   XXX X    X X XXXXX",
+            " XXX   XXXXXXXXX X XXXX   XXX",
+            " XXXX XXXX    XXXXXXXXXXXX XX",
+            "XXX     XXX X XX X  X      X ",
+            "X   X XX X XXXX XX XXXXX X XX",
+            "   XX  XX X XX   X   XX  XXXX",
+            "X   X X X XX    X X  X XX XXX",
+            "X X    XX XXX X XXX    X   XX",
+            "X   XXXXX XX  X X XXXXXX   XX",
+            "   XXX  XXX X  XX XX  X  XX  ",
+            "X   XXX     X XXXX        XXX",
+            " XXX X X XX X   XXX    XXX   ",
+            "X XX XX X XXX  XXX  XXXXX    ",
+            "        XX X XX   XXX   X  XX",
+            "XXXXXXX X X     XX XX X XXXXX",
+            "X     X  X X XX X   X   XX X ",
+            "X XXX X X XXXXXX    XXXXX   X",
+            "X XXX X  X X   X X  X   XX   ",
+            "X XXX X X X   X  X  X  XX X X",
+            "X     X X  X XXX XX XX X   X ",
+            "XXXXXXX  XX   X XX XX X X  XX"
+        };
+
+        private const string Text1 = "The quick brown fox jumps";
+
+        [Fact]
+        private void TestCode1()
+        {
+            var qrCode = EncodeText(Text1, Ecc.Quartile);
+            Assert.Same(Ecc.Quartile, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(29, qrCode.Size);
+            Assert.Equal(0, qrCode.Mask);
+            Assert.Equal(Modules1, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules2 = {
+            "XXXXXXX XXXXX X  XX  X    X    XXX    X XXX  X  X  XX XXXXXXX",
+            "X     X    XX  XXXXX XX XXXX     X  XX  XXX XXX  X XX X     X",
+            "X XXX X  X  X   XXXXX  XX  XX   XXX X   XX XXX  X XXX X XXX X",
+            "X XXX X XX X  X   X  X XXX   X XX XX X  X    XX  XX X X XXX X",
+            "X XXX X X   X XX X  XX X X XXXXXX  X XXXX X  X    XX  X XXX X",
+            "X     X XXXX   XXX  XX XX X X   XX  X XX XX  X XXXX   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X X X X X X X XXXXXXX",
+            "        X  X XXXXX  XXX  XXXX   X XXXX XXX    XXX   X        ",
+            "X   X XXX XXX XXXXX       X XXXXX XXX  X  X X   XX   XXXXX  X",
+            "XXXX      X X            X    X XX X  X   XX X  XXXX XXXX X  ",
+            " X XX X  X X  X  X  XXXX X XXX X  X   XXX X   X X X X X  XX  ",
+            "X  XXX X XX      X XXX   X  X     X X  X  X XXX XX XXXX X XX ",
+            "XX X XXX  XXXXXXX XX  XXX X   XXXX  X  X X XX   XXX X X X X  ",
+            "X X    X XXXX     X X   XX     XX   X XX XXXXX XX XX  X XX   ",
+            "  X   XX  XX X  XXXX  XXX XXXX X   X   X XXX  XX X XX XXX X  ",
+            "X XX     X  XXXX  X     X   X  X X X X XXXX   XX XXXX     X  ",
+            "XX  X X   XXX X XX      XXXXX X X  X XXXX X   XXXXXXXXX X XXX",
+            "X      X XXXXX  XX XXX  X   XXX X     X XXXX X   XXX XX   X  ",
+            "X XXX XX XXX X XX  XXX   XXX   X    X X  XXXXX  XXXX XX      ",
+            "XX  X  X       XX     XXX XXXX   XX  XX  XX XXX     XX    XX ",
+            "  XXX X X X X X  X  X  XX    X XXXXXXXXX XX X  XX    XX XX X ",
+            "X X    X X    X XXX XXX XXXX  XXXX  X X XXX  X  X XX  XX X X ",
+            "   XX X  X   XXX    XXXXXX XX  X  X  XX X    XXX X XX XX  X  ",
+            " XX X  XXXX X  XX X X  XX    X     X XXXX X  XXXXXX X  X  X  ",
+            "XX    XXXX X  XXX    XX X X XXXX  XXXX X    XX XX     X XXXXX",
+            " X XX    XXXXXXXXXXX XXX X XX X XXX X    X XXX XX XX XX XXX X",
+            "XXXXX X      X X XXX X XX    XX  XXX    XX    X  XX X  X X   ",
+            "X   X  X    X X  X X  X XXXXX  X X  XX X   XXX X     XX X X X",
+            " X XXXXXX     X  XXX  X   X XXXXX  XX X     XX XXXX XXXXX XXX",
+            "  XXX   X   XXX  XX XX XXX  X   XX X  XXXXX       XXX   XX XX",
+            "XXXXX X X  X X XX XX X   XX X X XXXX   XXXX    XXXX X X X X  ",
+            "  X X   X  XX X X     X XXXXX   X XXXXX XX    X   XXX   X X  ",
+            "   XXXXXX XX XXXXX     XX X XXXXX   X  X    XX XXX  XXXXX XXX",
+            "X X  X  X XX  X X   X  XXXXX  XXXX X  XXXXXXXX  X XX   XX XX ",
+            "    X XXXXX X XXXXX   X  X X  XXX X     XX   X XXX  X        ",
+            "X  XXX  X XXX X XXXXX X XX XXX    X     XX X X XXX  XX   XXXX",
+            " XX X XX X X XXXXXXX XX   X   XX X  X      XXXXXXXX X XX XX X",
+            "XX X   X XX  X  X X     XX  XX  XX XX XX XX XX  X X X X XX XX",
+            " X XX X X XXXXX  XXX XX X  XX    XXX  XXXXX  X XX  X X  XX  X",
+            "XX  X    XX    XXXXX   XXX X X X  X     XX  XXXXX     XXX XX ",
+            "    XXXX   X  XX XXX  XXXXXX XX XXXXXX X    X X XXX X  X XX X",
+            "XXXX X    XX XXX  X XXX X X X  X   XX X  XX XX X  X XXX XX X ",
+            " XXXXXX     XXX X XX  X    XX   XX  X XXX  X     X XX   XXXX ",
+            "  XXXX     XXX   XX  XXX  X   X  XXXX    X  XXX  X X  X X XXX",
+            "  XX XXXX   X X  X X XX X X XXXXXX  X X  XXXX XXXX  XXX XXX X",
+            "XX  XX  XXX    XX   XXXXXXX   X X   XXXX  X X  X XX X   XXXX ",
+            " XX  XXX X XXXX X  X   X   X  XXX XX X  X  X XXX XX XX    XX ",
+            "  XX X X XXX  XXXX   X X  XXXXX   XXXX  X   XXXX X X XX   XX ",
+            "XXX   XX X  XX XXXX       X XX  XX XXXXX  X X  XX       X X  ",
+            "XX XX    X XX XXXX X X XX  XX XXXX X  XX XX XX X  X     XX X ",
+            "  XXXXXX X X     XXXX  XXXXXX      X    X XX XXXX XX    XX   ",
+            "XXX X  XXX X  XX  XX  XX XXX  XXXXX XXX X XXX  XX X  X X XXX ",
+            "XXXX  XXX    XXX  X   X   X XXXXX   X  X   XX XXXX  XXXXX X X",
+            "        XXXX XXXX X XXXXXX  X   XX X  X  XXXXX    X X   X  X ",
+            "XXXXXXX X   X XXX X X X   X X X XXX XXXX  XXXXXX  XXX X XX   ",
+            "X     X  XX XX   XXXXX X  X X   XX X X XXXX  X XXX XX   X X  ",
+            "X XXX X X   X  XX  X  XX XX XXXXX  X  XXX    X XXX  XXXXX  XX",
+            "X XXX X   X X XX     XX XX   XXX X   XX XXXX X    X      X  X",
+            "X XXX X     X  X  X XX   XXX X XXX  X X  XXXX XX XX X    XXX ",
+            "X     X   X XXX X   XXXX  XX X  XXXX XXX XXXXX  XX XX  XX XX ",
+            "XXXXXXX X    X  X    X  X  X    X  XX X    XXX  XX      X XXX"
+        };
+
+        private const string Text2 = "kVtnmdZMDB wbhQ4Y0L0D 6dxWYgeDO7 6XEq8JBGFD dbA5ruetw0 zIevtZZkJL UnEcrObNuS COOscwe4PD PL2lKGcbqk uXnmfUX00E l4FsUfvkiU O8bje4GTce  C85HiEHDha EoObmX7Hef VEipzaCPV7 XpBy5cgYRZ VzlrmMTRSW f0U7Dt0x5j Mb5uk2JcA6 MFov2hnHQR";
+
+        [Fact]
+        private void TestCode2()
+        {
+            var qrCode = EncodeText(Text2, Ecc.Medium);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(61, qrCode.Size);
+            Assert.Equal(4, qrCode.Mask);
+            Assert.Equal(Modules2, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules3 = {
+            "XXXXXXX X  X XXXX XXXXXXX",
+            "X     X   X X   X X     X",
+            "X XXX X X X X XXX X XXX X",
+            "X XXX X X X XX XX X XXX X",
+            "X XXX X  X  X X   X XXX X",
+            "X     X X  XX   X X     X",
+            "XXXXXXX X X X X X XXXXXXX",
+            "        X  X X           ",
+            " X X XXXX  XX XX XXX XX X",
+            "XXX X   XX   X X X  XXX  ",
+            " X X  XXXX  XXXX  XXX    ",
+            " X  X    XX XX X XXXXXXXX",
+            "   XXXXX X XX X       XX ",
+            " X  XX X   X XX  XX  XX  ",
+            "X XX XX XXX  X XXX    XX ",
+            " X X X XX XXX XX    XX X ",
+            "XX  X X X  XXXX XXXXX X X",
+            "        XX  XX XX   XX XX",
+            "XXXXXXX XXX  X XX X X XX ",
+            "X     X X XX XXXX   X  XX",
+            "X XXX X  XXXX X XXXXX  XX",
+            "X XXX X X XX XX   XXXX   ",
+            "X XXX X    XXX    XX  X X",
+            "X     X X  X  X X  X XX  ",
+            "XXXXXXX  X   X   X  X XXX"
+        };
+
+        private const string Text3 = "😀 € éñ 💩";
+
+        [Fact]
+        private void TestCode3()
+        {
+            var qrCode = EncodeBinary(Encoding.UTF8.GetBytes(Text3), Ecc.Low);
+            Assert.Same(Ecc.Quartile, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(25, qrCode.Size);
+            Assert.Equal(7, qrCode.Mask);
+            Assert.Equal(Modules3, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules4 = {
+            "XXXXXXX    XX  X X   XXX   XX    XXX XXX X X  XX  XXXXXXX",
+            "X     X XXX X   XXX  X X  XX    XXX   X   X  X X  X     X",
+            "X XXX X  XX XX XX XX X XXX XXXX  X  XXXXXX X XXX  X XXX X",
+            "X XXX X   XX   X  X    XX X    XX X X X      X X  X XXX X",
+            "X XXX X    XXX   X X  XX XXXXXX XX X    X X X  X  X XXX X",
+            "X     X X XX XXX X XX X  XX   XX     XXXXXXXXXX   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X X X X X XXXXXXX",
+            "        X X X X   X X     X   X XXXX XX X X  XXX         ",
+            "    XXXX  XXX XX  XXXXX   XXXXXX   XXX       X  X XX   X ",
+            "   X    X       X  X XX    XXX     X   X X X   X    XX  X",
+            "XXXXXXXXXXX XXXX   X  X X XX X X  XXX  XXX XX XXX    XX  ",
+            "X X  X X X   X      XX XXX XX    X XX  XXX    X X  XX XX ",
+            "    X X  X  XXX XX XXXXXXXXXXX X      XXXXX   XXX X X XXX",
+            "  XX   XX  XXX  X  X  XX  XXX   XXXX XX X XX    XXX   XXX",
+            " XX X XX    X  X  X  X  X XX XXX   XXX     XXXX  X  X  XX",
+            " X   X   XX X XXXXX XXXXX        XXX XX X XX XXX XXXXX  X",
+            "X XXX XXXX XXX  X  XXXXXX XX       XXX     XXX  XX XXXX  ",
+            "  X     X X   X XX X  XX    X X    X   X X  X  X    XX  X",
+            " XX X XXXXX X  X   X X  X XXX XXX XXX  XXX    XXX    XX  ",
+            " XX  X X X    XXX   XXXXXX X     X XX  XXX      X  XX XX ",
+            "X    XX  X  XX X X XXXXXXXXX          XXXXX   XXX XXX XXX",
+            "XXXX X XX  XX XX   X  X   X   X  XXX XX X XX XX XXX XX X ",
+            " XX XXXX    XXX   X  XXX  XX  XXX  XXX     XXXX  X   XX  ",
+            "     X   XX X XX XX X  X     XXXXXXX XX XX X XXX XX X XX ",
+            "XXXXXXXXXX X X X     X  X XX XX    XXX   XXXXX  XX    XXX",
+            " XX XX  X XXXX   X XX XX  X XX     X   X  X X  X   X XX X",
+            " XX XXXXXXX    XX   XX X  XXXXX X XXX  XX     XXXXXXX X  ",
+            " XX X   XX X XXXX  X XXXXXX   X X  X    X X     X   XX X ",
+            "X   X X XX XXXXX X X XXXX X X XX   X  X       XXX X XX XX",
+            "XXXXX   X   X  X    X X  XX   XX     XXX X X XXXX   XX  X",
+            " XX XXXXXXX X    XX X  X XXXXXXX X XXX XXX XXXX XXXXXXX  ",
+            "       XXX  X XX XXX  XX  XXX XXX  X XXXXX X XXX   XX XX ",
+            "XXX   XX   XXXXX X X XX XX  XXX     XX XXXXXXX   XX   XXX",
+            " X  X  XX   X       XXXX   X  X     X   X X X   X XXX XXX",
+            " XXX XXX XX X  XXXX XX X X XX X XX  X         XX   X   XX",
+            " X  XX  XX  XXXXXXXX XXXX XX XX X  X    X X    XXX   X  X",
+            "X   X X    XXXXX X X XXXXXXXX XX  X X X       XXXXXX XX  ",
+            "XXX XX X   X   X      X    X  XX XX XXXX X X XXX  X  X  X",
+            " XX   XX  XX     X  X  X XXX XXX X  XX XXX XXXX     XXX  ",
+            "X      XXX XX XX  XXX XX   XX  XXX  X  XXX X   XXX XX XX ",
+            " X    X    X XXX X X XXXX X  XX  XXXX XXXXXXX XXX X   XXX",
+            " XX X  X   X   X X   XX X XXX X  X   XX X X XXXX  XXX XXX",
+            " XX  XXX XXX   XXXX  X  X  X  X XX X X       XX XXXX   XX",
+            "X   XX XX X  XX XXXXXXX  XX  XX  X  XXX X XX XXX     X  X",
+            " X XX XX  XXXXX XX X XX X  XX X X   XX     XX    XXX XX  ",
+            " X XXX X  XX     XX   XXX X   XXX   X  X X  X   X X  X  X",
+            "X X  XXX XXX    XX  XXX    X XXX X XX  XXX   XXX    XXX  ",
+            "XXXXX    XXXXX   XXXXX      X  XXX  XXXXXX     XXX XX XX ",
+            "      X XXXX    XX X X  XXXXXXXX XXXXX XXXX   XXXXXXX XXX",
+            "        XX X  X       XXX X   X  X      X XX XX X   X XXX",
+            "XXXXXXX XXXX    XXX  XX   X X XXXX X       XXXX X X X  XX",
+            "X     X X X  X   XXXXX   XX   XXXX  X X X XX XX X   XX  X",
+            "X XXX X X XXX  X X X X XXXXXXXXX    X X    XXX XXXXXXXX  ",
+            "X XXX X   XX  XXXXX   X   XXXXX     XX X X  X  XX  X  XXX",
+            "X XXX X  XXX X X X  XX XXXXXXX XXX XX  XXX    XX  XXX    ",
+            "X     X  XXXXX X XXXXX X  XX  X XX  X  XX X      XX XX  X",
+            "XXXXXXX  XX X X XX  X   XX X    XXXXXX XX     X XXXX XXXX"
+        };
+
+        private const string Text4 = "ABCD22340";
+
+        [Fact]
+        private void TestCode4()
+        {
+            var segments = QrSegment.MakeSegments(Text4);
+            var qrCode = EncodeSegments(segments, Ecc.High, 10, 40, 4, false);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(57, qrCode.Size);
+            Assert.Equal(4, qrCode.Mask);
+            Assert.Equal(Modules4, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules5 = {
+            "XXXXXXX X     X   XXXXXXX",
+            "X     X X X XXX X X     X",
+            "X XXX X   X   XXX X XXX X",
+            "X XXX X XX XXX  X X XXX X",
+            "X XXX X  X  XXXX  X XXX X",
+            "X     X  X  X   X X     X",
+            "XXXXXXX X X X X X XXXXXXX",
+            "        X  XXX X         ",
+            "X XX XXX X X  XX  X  X XX",
+            "    XX  X XXXX X  XX  XX ",
+            "XXX  XX  XX XXX  X   X   ",
+            "X   X  X     X  X X X X X",
+            " X XX XX X X  X   X  X  X",
+            " X  X   XXXX X  X  XX XXX",
+            " XXXX X X X X X XX  XXX X",
+            "X  X   XXXX XXX XXXXX  X ",
+            "  XX  XXXXXX X  XXXXXX X ",
+            "        X X XX XX   X  X ",
+            "XXXXXXX XXXXX   X X X  X ",
+            "X     X XXX X X X   X XX ",
+            "X XXX X  X XXX XXXXXXX XX",
+            "X XXX X XX  XX  X X   X X",
+            "X XXX X XX XXX XXXX XX X ",
+            "X     X  X     XXX    XX ",
+            "XXXXXXX X   X XX XXX  X X"
+        };
+
+        private const string Text5 = "314159265358979323846264338327950288419716939937510";
+
+        [Fact]
+        private void TestCode5()
+        {
+            var qrCode = EncodeText(Text5, Ecc.Medium);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(25, qrCode.Size);
+            Assert.Equal(3, qrCode.Mask);
+            Assert.Equal(Modules5, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules6 = {
+            "XXXXXXX    X   XX   XX XXXXXX XXXXXXX",
+            "X     X XX  XX  XXX X XXX  X  X     X",
+            "X XXX X X XXX      X XXXXX  X X XXX X",
+            "X XXX X X XXX X    X   X  XX  X XXX X",
+            "X XXX X X  XX      XXX X    X X XXX X",
+            "X     X X XXX XXXXXXX XX XXX  X     X",
+            "XXXXXXX X X X X X X X X X X X XXXXXXX",
+            "          X X X X   X    X XX        ",
+            "  X  XXXX   XXXXX XX  X  X X X XXXXX ",
+            " XX    XX  X   XX XX    XX    X      ",
+            "  XXXXX XXXX X     X XX X XX  X  X XX",
+            "  X      XXXXX XXX XX   XXX  XXX X X ",
+            "X XX XXXXXXX  XX XX   X   XX  XXX  XX",
+            "XXX X  X   X  XX  XXX     X XXX  X X ",
+            " XX X XX X  XXXXXXX X  XXX XXX XXX XX",
+            "XX  XX  X X X  XXX   X  X X XXXX    X",
+            "X X XXXXXX X XXXXXX  X  XXXXX X X XXX",
+            "  X    XXX X X  XXX    X   X X  X X X",
+            " X XX XX X X XXX      X   XXXXX    X ",
+            "X X XX        X   X X      X   XXXXXX",
+            " XXXXXXXXX X   XXX X  X X X  XX    X ",
+            "XX X X   X X XXXX   X X    XXXXX     ",
+            "XXX   XXXX  X  X   XX XXXXX  X XXX  X",
+            "XXX XX XXXX  XXX XXXX X X XX XXXXXXX ",
+            "XXX X X    X  XXXX   XXX XX XXX X XXX",
+            "    XX XXX  XXX  X    X   X X  XXXXX ",
+            "XX XX X  XXX X X      XX X  XX  X   X",
+            "  XX   XXXX     X  XX X   XXXX  XXXX ",
+            "XXXXXXX X XXX XX X    XXXXX XXXXXXXX ",
+            "        X  X X XXX XXXXX  XXX   XX   ",
+            "XXXXXXX X  XX  X  XXX X    XX X X   X",
+            "X     X X X XX   X      X X X   X XXX",
+            "X XXX X  X X  X XXX   X XX  XXXXXXX X",
+            "X XXX X  XX X XXX  X  X X   XXXX   X ",
+            "X XXX X XXX   X X X     X   X   XX XX",
+            "X     X    XXXX X XX   XX X  X   XX X",
+            "XXXXXXX   XXX XX  XXXX     X XXXX XXX"
+        };
+
+        private const string Text6 = "DOLLAR-AMOUNT:$39.87 PERCENTAGE:100.00% OPERATIONS:+-*/";
+
+        [Fact]
+        private void TestCode6()
+        {
+            var qrCode = EncodeText(Text6, Ecc.High);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(37, qrCode.Size);
+            Assert.Equal(1, qrCode.Mask);
+            Assert.Equal(Modules6, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules7 = {
+            "XXXXXXX XXXX X  X    X X  XXXXXXX",
+            "X     X  X    XXX XXXX    X     X",
+            "X XXX X  X  XX XX  XXXXX  X XXX X",
+            "X XXX X  X X      X  X  X X XXX X",
+            "X XXX X X   XX XX   XXX   X XXX X",
+            "X     X XX  XX     X X XX X     X",
+            "XXXXXXX X X X X X X X X X XXXXXXX",
+            "         X  XXX XX XX XX         ",
+            " XXXXXXX X     X  XX  XX   XX   X",
+            "  XXXX   X X   XXXXXX  X   XX X  ",
+            "X  XX X  XX  X X X X  X     XXX X",
+            "X XX X X  XXXX XXXXXX   X XX     ",
+            "   XXXX XX X  XX    XXX XXX XXXXX",
+            "XXX X   X  X XX XXX  X  X  XX X  ",
+            "XX XXXXX X  X XXX X X   X  XXXX X",
+            "XX  X  XXXXX X  X X   X  X  X XXX",
+            "      X         X X XX  X XXX    ",
+            "XX  XX  X XXX XX X   X XX X X XXX",
+            " XX XXX   X  XX XX X X X XX XX  X",
+            "X  X   X     X  XXX  XX X XX X XX",
+            " X XX X X X XX   X X X    XX   XX",
+            "XX X   XX  XXXXXX   XXXXXXX X X X",
+            "X X  XXXXXX  X XXX X X XX X   XXX",
+            "X XXXX XX XXX  XXX XX  X XXX X XX",
+            "X    XXX   XXXX X XXXX XXXXXX X  ",
+            "        XXX  X   XXX    X   X X X",
+            "XXXXXXX XXX X X    X  X X X XX XX",
+            "X     X X X X XX X  X   X   X    ",
+            "X XXX X XX   X  X X XXXXXXXXX XXX",
+            "X XXX X XX  X XXXXX  X X XX  X  X",
+            "X XXX X X XX X X    XX  X XXX    ",
+            "X     X X X   X  XX   X X  XX    ",
+            "XXXXXXX  XX XXX   X   XX XXX X X "
+        };
+
+        private const string Text7 = "こんにちwa、世界！ αβγδ";
+
+        [Fact]
+        private void TestCode7()
+        {
+            var qrCode = EncodeText(Text7, Ecc.Quartile);
+            Assert.Same(Ecc.Quartile, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(33, qrCode.Size);
+            Assert.Equal(2, qrCode.Mask);
+            Assert.Equal(Modules7, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules8 = {
+            "XXXXXXX X X XX X  XXX X XX X X X X  X   XXXX X  X XX   X  XX XXXXXX  XX  X     XXX  X XX  X    XX    XXX XX X XX  XXXXXXX",
+            "X     X X   XXX   X    XX X   X  XXXX X  XXXX   XX XX  X  X X  XXXX  XX  XX  XX      X XXXX XX     XXXXXX    XX X X     X",
+            "X XXX X XXX X      X XX X         X  XXXXX X   XXXXX    X XX X X X  XXXX  XX      XXX X      XX X X  X X XX X  XX X XXX X",
+            "X XXX X   XX       XX  X   XXX  X X   XXX X   XXX   X X X X   XXXXXXX  XXXXXXXX XX X   X  XXXXX       XX XXX XXXX X XXX X",
+            "X XXX X   X XXX    XXXX XXX XXXXX XXX X X XXXX X XX X XXXXXXXX        X XX X  XXXX XXXXXXX    XX   X  XX   XX  X  X XXX X",
+            "X     X XX XX  XX X      XXXX   X   X XX  X X  X  X    XX   XX  X XXX  XX     XXX   X   X X XX   X  XXX XX   XXX  X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X X XXXXXXX",
+            "        X      XXX       X  X   X X    X XX X  XXX  X XXX   XX X X XX X    X   X  XXX   X  X XXXX X  X   XXXXXXXX        ",
+            "  XXX X X XX  X  XX  XX X X XXXXXX   X  X  XXX  X    X  XXXXX    X XX X  X X  X    XXXXXXXXX X  XXX   XX   XXXX  XXX  XXX",
+            "  XXXX     XXX  XXXXX   XX      X  X  X XX X  X   XX XXX  XXXXXX XX  XX  X  X     XXX  XXXX XXXXX X  XXX X   XX X X XX   ",
+            "XX X XXX X   X XX     XXX   X XX XXX  X XXX XX    X   X X       X XX   XX X  XXXX    X XXXX X  X   XXXX X    X    XX   XX",
+            " X XXX XXXXX   X X   XXX X  XX X XX XXXX XX  XX   XX XX XXX X X XXX XX XX XXX  X XX XXX    X  XXX X  X X XXXX XXXXXXX   X",
+            "X   XXXXXX  X   XXX XX X  XX  XXXXXXX  XXXXXXX XXXXX X X X X XX  XX X XXXX  XX X X    X   X XX  X XX  X  X  XXX    XXXX  ",
+            "XX XXX  XX   XXXX X XXXXX   XX  XXX  XXX   XX XX     X X XX XX XXXX   XX XXXX   XX XXX XX X     XX X XX XX X XX XX  XX X ",
+            "XX   XXXX  X X XX XXXXX XXX X    XXX XXXXX  X XXX XXXXX X  XXXXXX      X  XX X  X  XXX XXXX X  X X XX X X       X      XX",
+            "X   XX XXX   X     XX  XX X   XXXXXXX X  XX  X XX X  XXXX  XX X X   XX  XXXXX XX XX  XX       XXXXXX   X XX X XXXXXXX  XX",
+            "X X  XX X XXX X XXXXXX X  X XXXX X  XXX XX  X  XX X XXX    X XX  X  X XX XXX XXX X       XXX   X     XX X   XX     X XXXX",
+            "  X       XX XXX  XXXXXXXXXX X    X   XXXX XXXXX XXX XX X XX XX X  XXX X X     X  XXXXXX XXX  XX  X  XXXXX   X  X XXX  X ",
+            "XX XXXX X     XXXX X XXX XX   X X    X XX   XXXX  XXXX XXX  XXX  X   X  XXXX   XXX  XX XXXX X    X XXXX X  XXX     X X XX",
+            "     X  XXX X   XXXXX     XXXX XX X XXXXX  X  XX  XXXXX X  XXXX    XX  XX XX  XX  X XXX      XXXX X    X XXXXXXXX X      ",
+            "  XX  XX XXXX XXX XX X X  X X   X  X X XX XX X  X X   XXXX  XXXXX    X  X XX XXX  X  XX  X XX   XXXX  X X   X        XX X",
+            "X X XX X XX   X  XX X X X XXXXX XXX X  X  XX XX  X XX X XX X      XXX X X    X  X XXX       XXX X     XXX X X   X X X    ",
+            "    X X X  XX X   X XX   XX X   X   X X   X X XX X X  XXXX X  XX   XX X  X    X X   X  XXXX XX   X XXXX X    X  X XX XXXX",
+            "X  X     XX XX   XXX XXXXXX XXXXX XXXXXXX      X X        X     XX X  XXXXX X X  XXXX X    X XXXX X  X X XX X X XXX XX XX",
+            "X    XX  XXXXX XX  XX XX   XXXX  XXXXX  XXX  XXX XX   XX  X X XX X XX XX   X XX  X   XXX     X XX  XX    X  X      XXXXX ",
+            "XX X   X XX  X X XX  X   X XXX X XX X XX    XXXX XX  XX X     X   X X    XX    X XXXX XX  XX X  XXX  XX XX X XX   X  X   ",
+            "  X  XXXX XXXXX XX XX X  XXXX XXX    XX XXX       X  X X X XXX X  XXXXX XXX X   XX  XX XXXX X    X XXXXXX          X X XX",
+            "    XX    XX   XXXXXXX   X  XX  X      XXXXX  XX   X  X X  XXXXXX  XX X  XXX  XX XXXX X       XXXXX    X XXXX X XXX      ",
+            "  X XXXXX   X   XXXX X X X  XXXXX  XX XXX X X XXX  X  XXXXXXXXX XX X X XX X  XXXX   XXXXX X  X     X X X XXX    XXXXX XXX",
+            "   XX   X X      XXXXX X  XXX   XX X X  XXX     XX XX X X   X X XXXXX   XXX XX XX  XX   X XX    XXXX   X  X    XX   XX   ",
+            " X XX X X    X  X XX XXXX X X X X  XXXX  X X  X  X X X  X X XXXX  XX X XXX XX  XX  XX X XXXXX  X X  XXX XX X X  X X X X X",
+            "XXX X   X XX XX X   X  XX X X   X  X XX     X   X  X    X   XXX   X  XXXXX XXXXX XX X   X  X XXXX X    X XXXXXXXX   X   X",
+            " X XXXXXXX   XXX XX XX X  XXXXXXXXX XX   XX  X  X   XXX XXXXXXX  XXX X X XXX  X X X XXXXX X X XXX    XX  X  XX XXXXXXXXX ",
+            "X XX   X XXXXXXX XX X XXXXX  X X      X  XXXX X X X XXXX XXXXX XX  X  X XXXXXX   X  XXXX X XXXXXX    X   X XXX  X     XX ",
+            "X XX  XX X  X   XXX XX  XX XXXX  XX XX X      XXX  X   XX X X  XX XX     X  X X XX XX XX XX X    X XXXX         XXX XX XX",
+            " XXXX  XXXXX XXXXXXXXX    X      X  X XXXX     X  X  XX   XX      XXXXX X    X X XXX X XXX   XXXXXX    X  XXX XXXX     X ",
+            "XX  X XXXX X XXXX  XX XXX    X  XX   XXXXX X X   XXX X X   X X   X   X XX  XXXX  XX   X  XXXXXX X  X     X  X  X XX X XX ",
+            "X XXXX X X  X XXX X    X X X   XX  XXXXXX X   X   X    XX X   X  X XXXXX   X X  X  XX  X XXXXXX X  X  X  X   XXX   XXX   ",
+            "XXX   X  XX  XX X X XX     XXXXXXX   X  X  XXXXX X XXXXX  X     X X  X  XXXX  X XX      X X XX   X XXXX X    X  X X XX XX",
+            "XX         X XXXX X  X XX XX X XXX    XX    X XX XXXXX X X X     X XXXX XXXX XXX XXX X  X  X XXXX XX     XXXX XXX XX   X ",
+            "X X   XX X XXX X XX  X   X   XXX    XXXXXXX X XXXXXX  XX  XX  XX XX  X X XXXXX X      X   X XX      X XX X X X  XXXXX X X",
+            "XX XXX     XX  X X X X  X XX X  X  XX  XXXX X XXX  XXXXXXX XX  XX  XXXX  XX X XXXXXX   X   XX XXX   X X  X XX      X X   ",
+            "XX X XXX  X      X     X   X  XXXXX X XX  XX X X XX X X     XX  XX  XX  X X   X X  XX  X XX X  X    XXX X       X X X   X",
+            " X XXX XX  X  X X X  X   X   X   X    X XX    X  X X X  XXXXXX XX    XX  XXXXX X XXX X XX  X XXXX X      XX X XXX      X ",
+            "XX XXXXXXX X  XXX  X X X  X  XX XX    XX XXXXX  XXX   XXX   XX X XX  XX X X  XX  X  XXXX  XXX XX   X  X  X X   XXXXX XXXX",
+            "X  X X   XXX X XX XX X  X XXXX  X X  X  X  XXX    X  XXXXX X   XXX X  X X XX   X  X X     X  XXX   X X X  XXX  XX   XX   ",
+            " X    X  X XX XX  XXXX XXXXXXX  XXXX  XX X  XX    X XXX X  XXX X XXXX  X X XXXXXX   XXXXX X X    X XXXX XX   X  X   XXX X",
+            " XX  X     XX X X  X X      XXXX XXXX   XXX XX  XXXX XXX   XXX XX X X    XX  XXX  XX X XX  X  XXX XX   X XXXX XX XXX     ",
+            "X X XXXXX  XX XX XX  X   XX   XXXXX  X     X  XX  X  XXXX XX  XXXXX  X        X  X  XXX  XX  X X  X  XX  X  XXXX XXX    X",
+            "X XXXX X  X XXXXX X    X XX XXXX X    XXXX    X  X XXXXXX XX XX  XX   XX   X   X X   XX XXXX X  X    XX    X  XX    X X  ",
+            "   XX X  X  XXX  XX XXXX   X  X  XXX XX X XXX       X X     XXX XXXX   X XXXX XXX       X X X    X XX XXX    X    X XXXXX",
+            "XXXX    XX  XX XXX   X X XX   X  XX  XX  XX X   X XX XXXXX  XX  XX   X  X  XXXXX  XX    X  X  XXX X    X  X X XXX XX    X",
+            " X    XX    X XXX X      XX XX XX XX XXXX XXXX XXXX XX X XXX XXXX    XXX XXX X X X  X X   X  XX X    XXXXX XX   XXX  XXXX",
+            "XX     XXX  XX   X    X        X  XX   X   X X   XX      XXX X   X X XXXX XX  XX X       X  X      XX XXXX     X X   XX  ",
+            " X    XXXXXX X   X     X  XXX         XX   X  XXX X  XX  XXX XXX X  X X X  XXX  X   X    XX X    X  XXX X    X  X X X  XX",
+            " XX XX      XXX  X XX XXX X X  X XXXX X XXXX    XX XXXX X X  X  XXXXXXX XXX XXXX XXX X XXX X XXXX X    X XXXXXXXX XX X  X",
+            "X  XXXXXX  XX X    XXXXX X  XXXXXXXX   XX   XXXX X    XXXXXXX     X   XX         X  XXXXX X   XXX X  XX     XX  XXXXXXX  ",
+            "    X   XX  XXX XX  X  X  X X   XXX   X  X   X XX XXXXXXX   X X XX  XXX XX  XX    X X   X    XX  X XX X XX X    X   X X  ",
+            "   XX X X XXX  X X X XXXXXXXX X X   XX  XXXXXXX XXXXX  XX X XXXXXXX  XX  X X X  X  XX X XXX X      XX X XX   X  X X XXXXX",
+            "   XX   X X   X XX   X    X X   XXX XX XX  X   X      X X   X   X XXX  XX XX XXX XXXX   X    XXXX X    X XXXX XXX   X  X ",
+            "   XXXXXXXX X XXXXXX   XX   XXXXXX XXX  XX XX  X XX   XXXXXXXXX  XX X XXXXXX      X XXXXXXXXX XX  XX    XX  XX  XXXXXXX X",
+            "X    X  XXXXX XXXXXX  XX XX X X   XXXXXX  X X XX  XXXXX X XX  XXX XXX XX    X X   X   XX XXX  XXX  XX X  X  XX X XX  X   ",
+            "   X  X X  XX X XXX X   XXXXXX  X X X  XXXX XX X X     XX   XXX      X X X X    X  XXX X XX X  X X XXXX X    X XX    X XX",
+            "XXXXX   XX  XXX    X   X X  X X X  X X  X X  XX  XXX XXXXXXXXX  XXXX  X X  X XXX  XXXX   X X XXXX XX   X  XXXXX XXX X    ",
+            "XX XX XX XX  X X  X XXX       XXX  X        X  X   XX XX     X X X   X    XXX    X XXX XX X XXXXXX  XXX     X  XXXX  XXX ",
+            "XX   X   X XXX XXX XXXX   X XXXXX XX   X XXX  XXXX  XXXX XX  X X X   XX  XXX X XXX X XXX  XXX   XX   XX  XXXXXX  XX    X ",
+            "    X XXXXX XX  XX X X  XXXXXX  XX  XX   XX XX  X XX X X      X   X XX  XX XX   X  XX  X XX X  X X XX X X  X X X    XX XX",
+            "XXX XX XX X XXX X   XXX XXXX XX XXX XXX XXXX X    X   XXXXXX   X   X X   XXXXX X XXXX   X  X  XXXXX    X XXXX XX X  XX XX",
+            "  XXX X  XX  XX X XXX  X    XXX XXXX XXX    X XXX X   X XXX     X   XX     XXXX   XXX  XX XXXX  XX XX XX X  X  XXX X XX X",
+            " X  X    XX X XXXX   X  X XX  X  X X X X  X  XXX XX     X    X X     XXXXX X X   XXX  X   X  X XX   XXXX  X XXX  XXX XXX ",
+            " XX X XXXX XXXXXXX X X    X   XX X XX XX X  XXX        X XXXXX    XXX XXX XX   XX  XXX X XXXX    X  XXX X      X X  X  XX",
+            " X      XX  X  XXX     X XXXX   XX   X X XXXX   X    XX   X  XXXXX  X XXX XXX XX XXXXX     X  XXX X  X X XXXX X   X X   X",
+            "   X  X  XX   X X XX  X    X  X X XXX  X    X  XX     X  X X XXXXXX  X     XXX  XX XX  XXXX   XXXX X  XX XXXX  XXX X XXXX",
+            "XX X X XXX X    X X XXX   XX   X X X  XXXXXX   X  X X   X  X X   XXXXX  XX X X XX     X   X   X       X X  X X   XXXX XX ",
+            "    X XX XX   X    X X X XXX XXXXX   XXX  X  X XX    X  X  X XXXXX X  X X XXXXX X  XXX X  XXX      XXXX X           X XXX",
+            "X X        XXX XX  X XX XX    X XXX X XXX X  XXXXXX   X        XXXXXXX X  XXXXX  XX  XX X  X XXXX X      XXXX XXX X X  XX",
+            "   XXXX  X     X  X X        XX XXX      XXX   X     XX  XXXX  X X  X    X   XXXX   X   X XX X X   X  XXXXX  X XXX    XXX",
+            " X X X XXXXXXX XX   XXX XX   XXX X  XXXX  XXX X X XXX X XXX  XXX  X  X XXXX XX XXX    X  X X  XX  X XX XX   X    XXX X   ",
+            "     XXX X  XX   X  XXX XX  X  X  X    X   X    XX    XXXXXX XXXXXX  X X XX X  XX  XXX X XX X    X XXXX X  X X     X X  X",
+            "XX XXX X X   X   X X X X  X     XXXX XXX X X   X  X X  XX  X XXXX   X  XX     XX XX XXXX     XX X X    X XXXX XX XX X    ",
+            "XXXXX X X   XXX X  XXX  XXX     X XX  XXXXX   X X X  XXXXXX XXX   XXX XXX   XX XXX XXX XX  XX  X X X XX  X  X  XX XX  X X",
+            "XX  X  XX    X XX  X   XXXXX  X   X  XXXX  XXXXX  X  XXXXXXXX X   XXXXXXX   XX XXXX  XX  XX     XXXX  X X X XXX  XX  X   ",
+            "   X XX  XX X       XXXXX  X X    XXX XXXX  XXX   XX XX     X      X    X  X XXXX  XX  X XX X       X X X  X X X     X  X",
+            " XX XX XX    XXX  XX X X X X XX  XX     XX XXX XXX X XXXX   X X X  XXX XXX XXX X XX XXXXXX    XXX X    X XXXX XX X  X  XX",
+            "X   XXXXXXX   X XXX X   X   XXXXX   X X X XX X  X X XXXXXXXXXXXX  X  X X X  XXXX X XXXXXX  X    X   X    XX  XX XXXXXXXXX",
+            "X XXX   X X  X XXXX    XX  XX   XXX XX XX  XXX  XX    X X   X     X X X XX XXXX X X X   XX  XX  X  X  X XX X    X   XX   ",
+            "   XX X XX XXXXX   X  XXXX XX X X XX X X   X   X  X X   X X X X    XXXXXXXXXXX  XX  X X X X X    X XXXX X    X  X X XX  X",
+            "X   X   X  XX XX   X  XX  X X   X   X X   X XX XX XX  XXX   XX   XXX   XX XXX  X XXXX   X  X XXXXXX    X XX X XXX   X   X",
+            "X XXXXXXX  XX     XX  X X X XXXXX XX  XXX X   X XXXX XXXXXXXXXXX X  XXX   XXXXX  X XXXXXX X  X X X  XXX  XX XXX XXXXX XXX",
+            " X XXX X    X   XX XXX     X X   XX XXX    XX   XX X  X X XXX       X XXX    XXX XX    XX X     XX   XX  X XX XX         ",
+            " XXX  XXXXX  XX   X XXXX X  XX X  XX XX   X X    XXXX   X  X XXX X  XXXX X XX  XXX  X X  XXX     X  XXX X  X X    XX X XX",
+            "X X    XXXXXX  X XX  XX XX X XX  XXXXXXX     X X X      X X  XX XX   XXX    XXXX XX XXXX   X  XXX X    X XXXX X X   XX  X",
+            " X X XXX    X XXX XXX  XXXXXX X XX XXX XXX   XXXXXX X XX X    X XX XXX   X XXX X   XX XX X    X XX X  XX    X XX  X XXX X",
+            "  X     X  XX XX X     XX X     X   X XXXXXX  X X X XX  XXX  XX XXXXX    XX X XX  X  X XXX   XX X  X XXX     X X XXX     ",
+            "XXX  XX X X   XX X  X  X X    XX XX  XX XX  XXX X XX X    X  XXXX  X XX  XXXXX  X    XX  XXXXX   X XXXXXX    X XXXXX   XX",
+            "XXX XX XX XXX    X XX     XX XX XX  XXXX XXXXXXXXXX XX X  X  XX XX XX  X  XX   X XX X   X  X XXXX XX   X XX XXX XX      X",
+            "  X XXX  X X  X X   X   X X   X   X X X XX  XXX         XX  X XXXX    XX     XXX   X XX XXX  X  XXXXX X   X    XX XXX X  ",
+            "     X XXXX   XXX  X  X  XX X XXX X  XX XXX XX XX    XXXX   X XX X XXX  XX XXX       X  XXX    XX XX     X XX XXX  X     ",
+            "XXX  XX XX XX   XXXX X      XX X XXX   X  X X X  X XXXX XX   XXXX   X XX XXX XX X  X  X   X X    X XX X XX   X X  XXXX XX",
+            " X XXX XX  XX X  X          XXXX X  X  XX X X  XX X  XXX  X XXXX    X  XX   X XX  X XX     X  X X X    X XXXXXX X  XX    ",
+            "XX   XXXXXXX XX X  XXXXXXX      X  XXXXX X  XXX    X  X   XX X XXX  X  XX  XX XXX  X X   X    X    X   XX   X  XXXX XXXX ",
+            "X   X       XX XXXXX       X   XX  X X XXXXXXXX   XXXXX  X XX X XXX XXXXXXX X    X   X XXX  X X X  X XX        X  XX     ",
+            "XXX X X      X X XX  X XXX      XXX X X XX X  XXX X X  X   XX  X   XX    XX X XXX    XXX  XXX    X XXXXXX  X X   XX  X  X",
+            "  XXX   XX XXXX X XX XXX  X X XXX   X   X XX   X XXXXXXX   XX X  XX   X  X X   X XXXXX X   X  XXX XX   X XXXXXX X    X   ",
+            "XX   XXXXX XX XX  X X XX X  X X X   XX XX    XX X   XXX X  XX XX  X X X XXX XXXXX  XXXXX   X   XXX    XXXX   X XX X XXX X",
+            "  X  X XX   X X XXXX   XX XXXX   X XX X  XX  X   X X  XX   X  XX  XXX X X  X  X     XX XXXXX X   XX   XXXX X  X X XX     ",
+            "XXX   XX X  XX  XXX  X XX X   X XX  X X     X   XXX XX  XXXXX     XX XX  X  X XXX  X  XX XX XX X X XXXXXX      XXXXXX  XX",
+            "X XXXX   XXXXXX XX X  XX  X X  X X  X  X XXXXXXXX X XXXX XXX X  X XXXX XX    XXX  X XX X X X XXXX XX   X XX X X XX X X XX",
+            "X   X X  X XXX X XX    XX X X  XX    XXX   XX X   XXX    XX XXX  XX XXXXX  X X  XX XX   XXXX    X  X  X   XX   X    XXX  ",
+            "X   X  X  X X X    X   XXX   X  X  XXXX X X      X X   XX X  XX XXXX XXXXXXXXX      X  XXX X    X     X   X X  X XXX  XX ",
+            "XX X XXXXXX     XXX X  X XX XXXXXXX X XX XX          X  XXX X    XX  X   XXXX XXX  XX X   X X  X X XXXX X    X X XXX  XXX",
+            "X XXXX   XX  XX  X  XX XX  X    XXXX      X  XX   X XX X X  XX    XXX   XX    XX XX    X   X XX X XX   X  X XXX     X    ",
+            " XXX  X  X    X     X XXX  XXXXXX   X X XXXXX XXXX    XXXXXXXX    XX XX  X  XX X   XXXXXX X XX X XX X XXX   XX XXXXXX X X",
+            "        X  XXXX XXXXXXXX XXXX   XXXXXXXXXXX    XXX X XX X   XXX X XXX  XX XX XXX X XX   X X    X XX  XXX   XX  XX   XXX  ",
+            "XXXXXXX   XX XX  XXX   X X  X X XX  XX  XX    X X XXX  XX X X   X   X XX  XXXXX X   X X XXXXX    X XXXXXXX   X  X X XX XX",
+            "X     X  X X     X   X    XXX   XX X  X  X X  X XXX    XX   X X     X  X X XX  X XX X   XX X XXXX XX   X XX XXX X   X  XX",
+            "X XXX X XX X  X  XX X X X  XXXXXX    X XX X     XX   XX XXXXXXXX  X X   X           XXXXXXXX   XX          X X  XXXXXXX  ",
+            "X XXX X XX X  XX XX XX  X  X   XXX X  XX    X  XXX XX X X XX  XX  XX XXXX XX X  X   XX XX   XX    X  XX  X  XX XX XX X  X",
+            "X XXX X XXXXXXX XXXXXX   X   XXX X X X XXX XXXXX X    XXXXXX X XXXXXX   X     X XX X X XXXX X       XXX X    X    XX X  X",
+            "X     X  XX X XXX  X X XX  X  X XXX XXX X X XXX XXXXXX X    X X X  X XX X X   XX XXXXXXX     XXXX X    X XXXXXX  XX     X",
+            "XXXXXXX       X X  X   X  X   X  XX  XXXX  X   X  X XX  X    X   X   X   XXXXX X X  X  X X X       XX XX XXX XXXXX   XXXX"
+        };
+
+        private const string Text8 = "Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, 'and what is the use of a book,' thought Alice 'without pictures or conversations?' So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.";
+
+        [Fact]
+        private void TestCode8()
+        {
+            var qrCode = EncodeText(Text8, Ecc.High);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(121, qrCode.Size);
+            Assert.Equal(2, qrCode.Mask);
+            Assert.Equal(Modules8, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules9 = {
+            "XXXXXXX   XXXXXX XXX  XXXXXXX",
+            "X     X XXXX X XXXXX  X     X",
+            "X XXX X X  X X X X    X XXX X",
+            "X XXX X X XXX X XX XX X XXX X",
+            "X XXX X XX  X   XXX   X XXX X",
+            "X     X X X XXX X   X X     X",
+            "XXXXXXX X X X X X X X XXXXXXX",
+            "         X XX X   XXX        ",
+            "  X  XXXXX XX XXXXXXXX XXXXX ",
+            " X XX   XX X XXX XX   X    XX",
+            "  X XXX XX X XX X XX X  X X X",
+            " X XX   XXX  X  X  XX X XX   ",
+            " X   XX X X X XXXXX  XX    X ",
+            "X  XXX XXX     X X XX X  X  X",
+            "XXXXX X X XX   X  XX     XX X",
+            "XX XXX X X X X XXX XX X  X  X",
+            " XX X X X XX  X X  XX XX     ",
+            "    XX X X X XX  X X  XX  X X",
+            "XX  XXX X   X X   XX      X X",
+            "  X     XXX  XXX   XXXX XX  X",
+            "XXXX  XX X  X    X  XXXXX   X",
+            "        X  XXX X  XXX   XX  X",
+            "XXXXXXX XXX   X  XX X X XXX X",
+            "X     X X    X X X XX   XX  X",
+            "X XXX X   XX      XXXXXXX    ",
+            "X XXX X  X    X  X XX  XXX X ",
+            "X XXX X XX X XX XX   X  X XXX",
+            "X     X  XX     X X X X  X   ",
+            "XXXXXXX   XXXXXXX   X XXXX  X"
+        };
+
+        private const string Text9 = "https://www.nayuki.io/";
+
+        [Fact]
+        private void TestCode9()
+        {
+            var segments = QrSegment.MakeSegments(Text9);
+            var qrCode = EncodeSegments(segments, Ecc.High, 1, 40, -1, true);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(29, qrCode.Size);
+            Assert.Equal(1, qrCode.Mask);
+            Assert.Equal(Modules9, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules10 = {
+            "XXXXXXX     X  XX X X XXXXXXX",
+            "X     X  XX  XXXX XXX X     X",
+            "X XXX X  X  XXX   X X X XXX X",
+            "X XXX X  XXX  XXXXXXX X XXX X",
+            "X XXX X X X  X X X X  X XXX X",
+            "X     X     X X    XX X     X",
+            "XXXXXXX X X X X X X X XXXXXXX",
+            "        XX  X    XXX         ",
+            "  XX  XXX       X  X XX X    ",
+            "XX  X   X  XXXX  X   XX X   X",
+            "XXXX XXXX XXX XX      X  XXX ",
+            "   X   XXX          X   X   X",
+            "  X X XX   XXX X  XXXX X XXXX",
+            "X XXX  X X X  XX   X  XX XX X",
+            " X  XXX  XX X X  X XXX XXX XX",
+            " X  XX X   XXX  XXXXXXX XX XX",
+            "X XX  XXXX XXXXX  X XX XXX XX",
+            " X   X   XXX  X XX     X XX  ",
+            "X X   XX  XXXX  XXX X XX X   ",
+            "     X   XXX X X X X XXXXXX X",
+            " X   XXXX  X  XX  X XXXXX XXX",
+            "        XX X X     XX   XX XX",
+            "XXXXXXX X   XXXXXX XX X X XX ",
+            "X     X   X    XXX  X   X    ",
+            "X XXX X      XX XXX XXXXXXX X",
+            "X XXX X XX X       X    XXXX ",
+            "X XXX X X   XX XX X X  X    X",
+            "X     X   X X  XX   XXX XX X ",
+            "XXXXXXX  X X  X   XXXX X   X "
+        };
+
+        private const string Text10 = "https://www.nayuki.io/";
+
+        [Fact]
+        private void TestCode10()
+        {
+            var segments = QrSegment.MakeSegments(Text10);
+            var qrCode = EncodeSegments(segments, Ecc.High, 1, 40, 3, true);
+            Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(29, qrCode.Size);
+            Assert.Equal(3, qrCode.Mask);
+            Assert.Equal(Modules10, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules11 = {
+            "XXXXXXX    X XX     X  XX XXX   X  XXX  X XXXXXXX",
+            "X     X X XXX XX XXXX XX   X X XX   X XXX X     X",
+            "X XXX X    X X  XX X XXXX  XXXXXXXX  X XX X XXX X",
+            "X XXX X  X XXX XXXX   XX X XXX XX XXXX X  X XXX X",
+            "X XXX X X  XXX XX   XXXXXXX  XX XXXX X    X XXX X",
+            "X     X   XXXXX X    XX   XXXXXXXXX  XX   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X XXXXXXX",
+            "            XXXXX XX  X   XXX  XXXXX XX          ",
+            "X X X X   XX  XX      XXXXXX   X XXX XX     X  X ",
+            "   XXX X XX XX  XXX X    XXX XX  XXXX XXXXX X  XX",
+            "XXXX XX X  XX  X X   X  X X XXX  XXX  XXX  XXX   ",
+            " X XX  X XX   XX XXX XXXX  XX  XXXX   X  XXX  X  ",
+            "X    XXX   X   X X  XXXX XXX  XXX XXX X          ",
+            "    XX   XX X       X XX XXX  X   XX  XXX X X X X",
+            "  X X XX X XX  XX       X XX   XX      XX   XX   ",
+            "X    X    XXXXXX XX X XX  XX XXXX  X XX  XX X X X",
+            "XXXXXXXXXXXXXX  X XX  X    X  X   X   X  X     XX",
+            "X X X   X XXXX  XXXXX XX  XXX XX  X   X   X    XX",
+            "XXX X XXXXX X X XX   XX    X       XX   X XXX    ",
+            " X X X XXX   X  XXX    X  XXXXX XXX X  X X  XXX X",
+            "XX XX X      X               XX  XX  X    X    XX",
+            " X XXX  X  XX  X XX XXXX  XX   X    XXX XXX XXXXX",
+            "  X XXXXXX XX  XX XXXXXXXXX    XX  XXXX XXXXX    ",
+            "XXXXX   X X  XX XX X XX   XX XXX XXXXXX X   X    ",
+            "XXX X X X XX XXXX   XXX X X   X  XX XX XX X X  XX",
+            "  XXX   X   XXX X XXX X   XX XXX X   XX X   X  X ",
+            "XXX XXXXX  XX XX XXX XXXXXX    X     XX XXXXXXXX ",
+            "X  X X   X    XX  XXX  XXX X   XXXXX XXX X  XXX X",
+            " XXXX XX  X XX   X XXXX X X  XXXX X  XXX XX    XX",
+            "    X  XXXX  XXXX  X    X  X XXX XXX XXXX X X  XX",
+            "X XXX X X XXX XXXX XX X    X    XX X XX X    X X ",
+            " XXXXX  XX  XX  XXXX X  XX X   XX  XX  X    XXXX ",
+            "   XXXX  XXXX X X  X  X X X XX X  XX   X XX  XXX ",
+            "XX X X    X  X   X XXXXXXX  XXXX XXX XXXX X X X X",
+            " X    XXX X XX X XXX  X X    XXX X   XX    XXXX  ",
+            "  X XX XX  XX    XX   XXXX XXX XXXXXXX  X  XX XX ",
+            " X  X X X  XX XX   X  X    X XXX X X XX X  X     ",
+            "  X X  X    X XXX  XXXX XX XX X X   X XX  XXXXXX ",
+            " X   XXXXXX X     X XXXX       X       X   XXX   ",
+            " XXX   X XX    X     X XXXX X X X XXXX   X X  X  ",
+            "XXX   XXX X X  XXX  XXXXXXX  X   X XX XXXXXXX  XX",
+            "        X X  X   XX X X   XX  X X XX    X   X X X",
+            "XXXXXXX  X XX XXXXXX XX X XXX  X   XX   X X X  XX",
+            "X     X  XX  X XX   X X   X X   X X X  XX   XXXX ",
+            "X XXX X XX X X XX   X XXXXX   XXX X    XXXXXXX X ",
+            "X XXX X  X XX XX X  X  XXX  XXX  XX XXXXXX   XXX ",
+            "X XXX X XXX XX XX    XXX XXX XX    X  XX XX  XX  ",
+            "X     X   XXXXX  XX XX XXX XX     X XXX   X  XXX ",
+            "XXXXXXX X X   X  X   X XXXX  XX  XX  X  X  XXX XX"
+        };
+
+        private const string Text11 = "維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫";
+
+        [Fact]
+        private void TestCode11()
+        {
+            var segments = QrSegment.MakeSegments(Text11);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 0, true);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(49, qrCode.Size);
+            Assert.Equal(0, qrCode.Mask);
+            Assert.Equal(Modules11, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules12 = {
+            "XXXXXXX XX    XX X XXX  XXX XX XXX  X   X XXXXXXX",
+            "X     X  XX XXX   X XXX  X      XX XXXXXX X     X",
+            "X XXX X XX     XX     X XX  X X X XX   XX X XXX X",
+            "X XXX X     X   X XX XX     X   XXX X  X  X XXX X",
+            "X XXX X  X  X   XX XX XXXXXX  XXX X       X XXX X",
+            "X     X XXX X XXXX X  X   X X X X XX  X   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X XXXXXXX",
+            "         X XX X XXX  XX   X XX  X X   XX         ",
+            "X X   XX XX  XX  X X XXXXXX  X    X   XX   X  X X",
+            " X  X     XXX  XX XXXX X  X   XX  X XXX X XXXX  X",
+            "X X   XXXX  XX     X   XXXXXX XX  X  XX XX  X  X ",
+            "    XX    XX XX   X   X XX  XX  X XX XXX  X  XXX ",
+            "XX X  X  X   X     XX X   X  XX XXX XXXX X X X X ",
+            " X XX  X  XXXX X X XXXX   X  XXX XX  XX XXXXXXXXX",
+            " XXXXXX     XX  XX X X XXXX  X  XX X X  XX XX  X ",
+            "XX X   X XX X X   XXXXX  XX   X XX    XX  XXXXXXX",
+            "X X X X X X X  XXXX  XXX X   XXX XXX XXX   X X  X",
+            "XXXXXX XXXX X  XX X XXX  XX XXX  XXX XXX XXX X  X",
+            "X XXXXX X XXXXXXX  X  XX X   X X X  XX XXXX XX X ",
+            "        X  X   XX XX X   XX X XXX XXXX     XX XXX",
+            "X   XXXX X X   X X X X X X X  XX  XX   X XXX X  X",
+            "    X  XXX  XX    XXX X  XX  X   X XX XXX XXX X X",
+            " XXXXXXXX   XX  XXX X XXXXXX X  XX  X XXXXXXXX X ",
+            "X X X   XXXX  XXX     X   X   X   X X XXX   XX X ",
+            "X XXX X XXX   X XX XX X X XX XXX  XXX   X X XX  X",
+            " XX X   XX XX XXXXX XXX   X   X    X  XXX   XX   ",
+            "X XXXXXXXX  XXX   X   XXXXXX X   X X  XXXXXXX X  ",
+            "XX     X   X XX  XX XX  X    X  X X   X    XX XXX",
+            "  X XXX  XXXX  X    X XXXXXX  X XXXX  X   XX X  X",
+            " X XXX  X XX  X XX   X XXX    X   X   X XXXXXX  X",
+            "XXX XXXXXXX XXX X   XXXX X   X XX     XXXX X     ",
+            "  X X  XX  XX  XX X    XX    X  XX  XX   X XX X  ",
+            " X  X XX  X XXXXXX   XXXXXXXX    XX  X    XX  X  ",
+            "X      X XXX   X    X X X  XX X   X   X XXXXXXXXX",
+            "   X XX XXXXX     X  XXXXX X  X    X  XX X  X XX ",
+            " XXXX   XX  XX X  XX XX X   X   X X X  XXX  XXX  ",
+            "   XXXXXXX  XXX  X   XXX X    X       XXXX   X X ",
+            " XXXXX   X XXXX XX  X XXX   XXXXXX XXXX  XX X X  ",
+            " X   XX X XXXX X XXXX X  X X X   X X X   X  X  X ",
+            " XXX      XX X   X X    X XXXXXXXXX X  X     XXX ",
+            "XXX   X XXXXXX  X  XX XXXXXX   X    XXX XXXXXX  X",
+            "        XXXX   X  XXXXX   X  XXXXXX  X XX   XXXXX",
+            "XXXXXXX X   XXX X X   X X X XX   X  XX XX X XX  X",
+            "X     X   XX    XX XXXX   XXXX XXXXXXX  X   X X  ",
+            "X XXX X         XX XXXXXXXXX XX XXXX X  XXXXX    ",
+            "X XXX X     XXX    XXX  X  XX XX  XXX X X  X  X  ",
+            "X XXX X X XXX   XX X  X   X   XX X   XX   XX  XX ",
+            "X     X  XX X XX  XXX   X   XX X XXXX XX XXX  X  ",
+            "XXXXXXX XXXX XXX   X    X XX  XX  XX   XXX  X   X"
+        };
+
+        private const string Text12 = "維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫";
+
+        [Fact]
+        private void TestCode12()
+        {
+            var segments = QrSegment.MakeSegments(Text12);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 1, true);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(49, qrCode.Size);
+            Assert.Equal(1, qrCode.Mask);
+            Assert.Equal(Modules12, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules13 = {
+            "XXXXXXX  X    XX X XXX  XXX XX XXX  X   X XXXXXXX",
+            "X     X XXX  XX     XXX XX    X XX X XXXX X     X",
+            "X XXX X XXXX XXX X XX  XX X  XXX     X XX X XXX X",
+            "X XXX X X X   X    XXX  X X   X  X     X  X XXX X",
+            "X XXX X  XXXXXX       XXXXXXXXX    X X    X XXX X",
+            "X     X  XX   XXXXXX  X   X X   X XXX X   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X XXXXXXX",
+            "        XX X  X XX   XX   X XXX X X X XX         ",
+            "X     X XX X    X   XXXXXXX X  XX  X X XXXX  XXX ",
+            "XXX     X  X  XX   X XXXX   X  XX    X     X XX  ",
+            "XX  XXX  XXXX X XX  X X X  X XX X  X       X  X  ",
+            "X   XX    XXXXX       X  X  XXX X XXXXXX     XXXX",
+            "XX X  X  X   X     XX X   X  XX XXX XXXX X X X X ",
+            "XX XX  X  XX X X XXXXXX X X  X X XX XXX XX XXXXX ",
+            "   X  XXX XXX X     XXX X   X  X XX   X       X  ",
+            " XXXX  XXX      X  X X  XX  X    XX X  XX  X X X ",
+            "XX   XXX   XXXXX  XXXX    X X X XX     XXX  XXXXX",
+            " XXXXX XXXX    XX   XXX XXX XX   XXXXXXX X X X   ",
+            "X XXXXX X XXXXXXX  X  XX X   X X X  XX XXXX XX X ",
+            "X       X  XX  XX  X X  XXX X  XX XX X    XXX XX ",
+            "XXX   X XXX  XXXX   XXX   XXXXX X    XXXX X XXXXX",
+            "X X    X XX  XX X  X    XX  XXX XXXX   X   X     ",
+            "   XXXXXX XXX X   XX  XXXXXXX  X XXXXX XXXXXXXX  ",
+            "  X X   XXXXX XXX X   X   X       X   XXX   XX XX",
+            "X XXX X XXX   X XX XX X X XX XXX  XXX   X X XX  X",
+            "XXX X   XX X  XXXX  XXX   X        XX XXX   XX  X",
+            "XX XXXXXXXXXX   XXXXX XXXXXXX  XXXX  X XXXXXX  X ",
+            " XX X  XX XXXX  XX   XX   X XXX     X   X XX   X ",
+            " X    XXXX  XXXXXX X    X  XXXXX X   X  XXX XXXXX",
+            "XX XXX  X XXX X XXX  X X X        X X X XX XXX   ",
+            "XXX XXXXXXX XXX X   XXXX X   X XX     XXXX X     ",
+            "X X X  XX  X   XX      X     XX XX   X   XXXX X X",
+            "  X  XX X  XX  X   XXX  X  X X XXX X  X XXX X  X ",
+            "  X X  XXX XX XXX X       XX    X   X    X X X X ",
+            " XXXX XX X  XXX XXXXXX  X XXXXXXX X  X XX  X     ",
+            "XXXXX   XX   X X   X XX     X X X X    XXXX XXX X",
+            "   XXXXXXX  XXX  X   XXX X    X       XXXX   X X ",
+            "XXXXXX   X X XX XXX X XX    XX XXX X XX  X  X X X",
+            " X   XXX    X XXX X    X  XXX  XXXX   X X  X  X  ",
+            " XXX    X  XXXX XXXXX X    X X X X    XXX X XX XX",
+            "XXX   XX X  X X  X    XXXXXXXX  X XXX   XXXXXXXXX",
+            "        XXXXX  X   XXXX   X  X XXXX XX XX   XXXX ",
+            "XXXXXXX     XXX X X   X X X XX   X  XX XX X XX  X",
+            "X     X   XXX   XXXXXXX   XXXXXXXXXX X  X   X X X",
+            "X XXX X   XX XX      XXXXXXXX XX X    X XXXXX XX ",
+            "X XXX X   X  X  X XX XX   XX   XX  X      XXX   X",
+            "X XXX X     XXX     X  X X  XXX XXXX    XXX X    ",
+            "X     X  XX   XX   XX       XXXX XXX  XX X X  X X",
+            "XXXXXXX XXXX XXX   X    X XX  XX  XX   XXX  X   X"
+        };
+
+        private const string Text13 = "維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫";
+
+        [Fact]
+        private void TestCode13()
+        {
+            var segments = QrSegment.MakeSegments(Text13);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 5, true);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(49, qrCode.Size);
+            Assert.Equal(5, qrCode.Mask);
+            Assert.Equal(Modules13, TestHelper.ToStringArray(qrCode));
+        }
+
+        private static readonly string[] Modules14 = {
+            "XXXXXXX    X XX     X  XX XXX   X  XXX  X XXXXXXX",
+            "X     X    XXXXXXXX X  X X XXX  X X XXXXX X     X",
+            "X XXX X      XX X  XXXX X XXX XX XXX X XX X XXX X",
+            "X XXX X  X XXX XXXX   XX X XXX XX XXXX X  X XXX X",
+            "X XXX X   XXX  X   XXXXXXXX XXXXXX X      X XXX X",
+            "X     X X X XX  XX  XXX   XXX XX XXX XX   X     X",
+            "XXXXXXX X X X X X X X X X X X X X X X X X XXXXXXX",
+            "          X X XX  X   X   XX    XX X  X X        ",
+            "X  X XX X X    X X  X XXXXXX X XXXX  X   X X     ",
+            "   XXX X XX XX  XXX X    XXX XX  XXXX XXXXX X  XX",
+            "X XXXXXXX XXXX XXX X XX XXX  XXX X X XXX    XXX  ",
+            " XXXXX XXXXX   X  XXXXX X XXXX X XXX      XXX XX ",
+            "X    XXX   X   X X  XXXX XXX  XXX XXX X          ",
+            " X   X X X  XX  X  XX  X  XXX XX   X XXX  XXX   X",
+            "    XXXXXX  X XXXX  X  XX  X X X   X  XXXX   X X ",
+            "X    X    XXXXXX XX X XX  XX XXXX  X XX  XX X X X",
+            "X XX XX XX XX     X      X XX XX     XX XX X  XXX",
+            "X   XX    X XXX X XX  X    XXXXXX XX     XX X   X",
+            "XXX X XXXXX X X XX   XX    X       XX   X XXX    ",
+            "   XXX  XXX      XXX  XX XXX XXXXX  XX XXX XXX  X",
+            "XXXXXXX X  X XX  X  X  X  X   X XXXX XX  XX X   X",
+            " X XXX  X  XX  X XX XXXX  XX   X    XXX XXX XXXXX",
+            " XX XXXXXXXXXX X  X XXXXXXX X   X XXX X XXXXX X  ",
+            "XX XX   X XX X  X  XXXX   XX  XXXXX XX  X   X  X ",
+            "XXX X X X XX XXXX   XXX X X   X  XX XX XX X X  XX",
+            " XXXX   X X X X   X X X   XXXXX  XX   X X   X XX ",
+            "XX  XXXXX   X  X  XXXXXXXXX  X XX  X X  XXXXXXX  ",
+            "X  X X   X    XX  XXX  XXX X   XXXXX XXX X  XXX X",
+            "  XX  X     X   XX  XX  XXX XXX X     XXXXXX  XXX",
+            "  X XX X XXX X XXX XX  XX XX  XXXXX  X XXXX     X",
+            "X XXX X X XXX XXXX XX X    X    XX X XX X    X X ",
+            "  XX X XXXX X    XX  XX X  XX   X XXXX XX  XXX X ",
+            "  XXX X XXX X   XX XX XXX   X  XX X   XX  X XXX  ",
+            "XX X X    X  X   X XXXXXXX  XXXX XXX XXXX X X X X",
+            "    X X X   X  XXXX     XX  XXX  XX   X X   XX   ",
+            "    X  X    X X   X X X XXXXX  X XX XXX XX X  X  ",
+            " X  X X X  XX XX   X  X    X XXX X X XX X  X     ",
+            " XX       X XXXX    XX  X  X  XXX X XXXXX X XX X ",
+            " X   XXX XXXX X  XX  XX   X  X XX  X  XX X X X X ",
+            " XXX   X XX    X     X XXXX X X X XXXX   X X  X  ",
+            "XXX   X X   XX X X XXXXXXXX XX X XXXXXXXXXXXX XXX",
+            "        X XX XX   X   X   XX XX   X   X X   X XXX",
+            "XXXXXXX  X XX XXXXXX XX X XXX  X   XX   X X X  XX",
+            "X     X XX     X   XX X   X    XX   XX XX   XX X ",
+            "X XXX X  X   XXXXX    XXXXX  XXX  XX  XXXXXXXX   ",
+            "X XXX X XX XX XX X  X  XXX  XXX  XX XXXXXX   XXX ",
+            "X XXX X  X  X  X   X X X  XXXXXX  XX XXXXXXX X   ",
+            "X     X   X XX    X  X  XXXXXX  X XXXX   XX XXX  ",
+            "XXXXXXX X X   X  X   X XXXX  XX  XX  X  X  XXX XX"
+        };
+
+        private const string Text14 = "維基百科（Wikipedia，聆聽i/ˌwɪkᵻˈpiːdi.ə/）是一個自由內容、公開編輯且多語言的網路百科全書協作計畫";
+
+        [Fact]
+        private void TestCode14()
+        {
+            var segments = QrSegment.MakeSegments(Text14);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 7, true);
+            Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
+            Assert.Equal(49, qrCode.Size);
+            Assert.Equal(7, qrCode.Mask);
+            Assert.Equal(Modules14, TestHelper.ToStringArray(qrCode));
+        }
+
+
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrCodeTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
@@ -613,7 +613,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode9()
         {
             var segments = QrSegment.MakeSegments(Text9);
-            var qrCode = EncodeSegments(segments, Ecc.High, 1, 40, -1, true);
+            var qrCode = EncodeSegments(segments, Ecc.High);
             Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
             Assert.Equal(29, qrCode.Size);
             Assert.Equal(1, qrCode.Mask);
@@ -658,7 +658,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode10()
         {
             var segments = QrSegment.MakeSegments(Text10);
-            var qrCode = EncodeSegments(segments, Ecc.High, 1, 40, 3, true);
+            var qrCode = EncodeSegments(segments, Ecc.High, 1, 40, 3);
             Assert.Same(Ecc.High, qrCode.ErrorCorrectionLevel);
             Assert.Equal(29, qrCode.Size);
             Assert.Equal(3, qrCode.Mask);
@@ -723,7 +723,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode11()
         {
             var segments = QrSegment.MakeSegments(Text11);
-            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 0, true);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 0);
             Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
             Assert.Equal(49, qrCode.Size);
             Assert.Equal(0, qrCode.Mask);
@@ -788,7 +788,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode12()
         {
             var segments = QrSegment.MakeSegments(Text12);
-            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 1, true);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 1);
             Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
             Assert.Equal(49, qrCode.Size);
             Assert.Equal(1, qrCode.Mask);
@@ -853,7 +853,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode13()
         {
             var segments = QrSegment.MakeSegments(Text13);
-            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 5, true);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 5);
             Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
             Assert.Equal(49, qrCode.Size);
             Assert.Equal(5, qrCode.Mask);
@@ -918,7 +918,7 @@ namespace IO.Nayuki.QrCodeGen.Test
         private void TestCode14()
         {
             var segments = QrSegment.MakeSegments(Text14);
-            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 7, true);
+            var qrCode = EncodeSegments(segments, Ecc.Medium, 1, 40, 7);
             Assert.Same(Ecc.Medium, qrCode.ErrorCorrectionLevel);
             Assert.Equal(49, qrCode.Size);
             Assert.Equal(7, qrCode.Mask);

--- a/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class QrSegmentEncodingTest
     {

--- a/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentEncodingTest.cs
@@ -1,0 +1,158 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class QrSegmentEncodingTest
+    {
+
+        private static readonly string TextNumeric = "83930";
+
+        private static readonly int BitLengthNumeric = 17;
+
+        private static readonly byte[] BitsNumeric = { 139, 243, 0 };
+
+        private static readonly string TextAlphanumeric = "$%*+-./ 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        private static readonly int BitLengthAlphanumeric = 242;
+
+        private static readonly byte[] BitsAlphanumeric = {
+            43, 63,240, 245, 223, 12, 64, 232,
+            162, 147, 168, 116,228, 172,  40, 21,
+            170, 67, 243, 58, 211, 175, 81, 76,
+            109, 33, 107, 218, 193, 225, 2
+        };
+
+        private static readonly string TextUtf8 = "😐ö€";
+
+        private static readonly int BitLengthUtf8 = 72;
+
+        private static readonly byte[] BitsUtf8 = { 15, 249, 25, 9, 195, 109, 71, 65, 53 };
+
+        [Fact]
+        void NumericEncoding()
+        {
+            QrSegment segment = QrSegment.MakeNumeric(TextNumeric);
+            Assert.Equal(segment.EncodingMode, QrSegment.Mode.Numeric);
+            Assert.Equal(TextNumeric.Length, segment.NumChars);
+
+            BitArray data = segment.GetData();
+            Assert.Equal(BitLengthNumeric, data.Length);
+
+            Assert.Equal(BitsNumeric, BitArrayToByteArray(data));
+        }
+
+        [Fact]
+        void RejectNonNumeric()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => QrSegment.MakeNumeric("abc"));
+        }
+
+        [Fact]
+        void AlphanumericEncoding()
+        {
+            QrSegment segment = QrSegment.MakeAlphanumeric(TextAlphanumeric);
+            Assert.Equal(segment.EncodingMode, QrSegment.Mode.Alphanumeric);
+            Assert.Equal(TextAlphanumeric.Length, segment.NumChars);
+
+            BitArray data = segment.GetData();
+            Assert.Equal(BitLengthAlphanumeric, data.Length);
+
+            Assert.Equal(BitsAlphanumeric, BitArrayToByteArray(data));
+        }
+
+        [Fact]
+        void RejectNonAlphanumeric()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => QrSegment.MakeAlphanumeric("abc,def"));
+        }
+
+        [Fact]
+        void AutoNumericEncoding()
+        {
+            List<QrSegment> segments = QrSegment.MakeSegments(TextNumeric);
+            Assert.Single(segments);
+
+            QrSegment segment = segments[0];
+            Assert.Equal(segment.EncodingMode, QrSegment.Mode.Numeric);
+            Assert.Equal(TextNumeric.Length, segment.NumChars);
+
+            BitArray data = segment.GetData();
+            Assert.Equal(BitLengthNumeric, data.Length);
+
+            Assert.Equal(BitsNumeric, BitArrayToByteArray(data));
+        }
+
+        [Fact]
+        void AutoAlphanumericEncoding()
+        {
+            List<QrSegment> segments = QrSegment.MakeSegments(TextAlphanumeric);
+            Assert.Single(segments);
+
+            QrSegment segment = segments[0];
+            Assert.Equal(segment.EncodingMode, QrSegment.Mode.Alphanumeric);
+            Assert.Equal(TextAlphanumeric.Length, segment.NumChars);
+
+            BitArray data = segment.GetData();
+            Assert.Equal(BitLengthAlphanumeric, data.Length);
+
+            Assert.Equal(BitsAlphanumeric, BitArrayToByteArray(data));
+        }
+
+        [Fact]
+        void Utf8Encoding()
+        {
+            List<QrSegment> segments = QrSegment.MakeSegments(TextUtf8);
+            Assert.Single(segments);
+            QrSegment segment = segments[0];
+            Assert.Equal(segment.EncodingMode, QrSegment.Mode.Byte);
+            Assert.Equal(Encoding.UTF8.GetBytes(TextUtf8).Length, segment.NumChars);
+
+            BitArray data = segment.GetData();
+            Assert.Equal(BitLengthUtf8, data.Length);
+
+            Assert.Equal(BitsUtf8, BitArrayToByteArray(data));
+        }
+
+        [Fact]
+        void EmptyTest()
+        {
+            List<QrSegment> segments = QrSegment.MakeSegments("");
+            Assert.Empty(segments);
+        }
+
+        private static byte[] BitArrayToByteArray(BitArray buffer)
+        {
+            int len = buffer.Length;
+            byte[] result = new byte[(len + 7) / 8];
+            buffer.CopyTo(result, 0);
+            return result;
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
@@ -1,0 +1,75 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+using Xunit;
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    public class QrSegmentRegexTest
+    {
+        [Fact]
+        void IsNumeric()
+        {
+            Assert.Matches(QrSegment.NumericRegex, "1234");
+        }
+
+        [Fact]
+        void EmptyIsNumeric()
+        {
+            Assert.Matches(QrSegment.NumericRegex, "");
+        }
+
+        [Fact]
+        void TextIsNotNumeric()
+        {
+            Assert.DoesNotMatch(QrSegment.NumericRegex, "123a");
+        }
+
+        [Fact]
+        void WhitespaceIsNotNumeric()
+        {
+            Assert.DoesNotMatch(QrSegment.NumericRegex, "123\n345");
+        }
+
+        [Fact]
+        void ValidAlphanumeric()
+        {
+            Assert.Matches(QrSegment.AlphanumericRegex, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./");
+        }
+
+        [Fact]
+        void EmptyIsAlphanumeric()
+        {
+            Assert.Matches(QrSegment.AlphanumericRegex, "");
+        }
+
+        [Fact]
+        void InvalidAlphanumeric()
+        {
+            Assert.DoesNotMatch(QrSegment.AlphanumericRegex, ",");
+            Assert.DoesNotMatch(QrSegment.AlphanumericRegex, "^");
+            Assert.DoesNotMatch(QrSegment.AlphanumericRegex, "(");
+            Assert.DoesNotMatch(QrSegment.AlphanumericRegex, "a");
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
+++ b/dotnet/QrCodeGeneratorTest/QrSegmentRegexTest.cs
@@ -23,7 +23,7 @@
 
 using Xunit;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class QrSegmentRegexTest
     {

--- a/dotnet/QrCodeGeneratorTest/SvgTest.cs
+++ b/dotnet/QrCodeGeneratorTest/SvgTest.cs
@@ -24,9 +24,9 @@
 using System.IO;
 using System.Text;
 using Xunit;
-using static Io.Nayuki.QrCodeGen.QrCode;
+using static IO.Nayuki.QrCodeGen.QrCode;
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     public class SvgTest
     {

--- a/dotnet/QrCodeGeneratorTest/SvgTest.cs
+++ b/dotnet/QrCodeGeneratorTest/SvgTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/SvgTest.cs
+++ b/dotnet/QrCodeGeneratorTest/SvgTest.cs
@@ -21,25 +21,25 @@
  *   Software.
  */
 
-using System.Drawing.Imaging;
+using System.IO;
+using System.Text;
 using Xunit;
 using static Io.Nayuki.QrCodeGen.QrCode;
 
 namespace Io.Nayuki.QrCodeGen.Test
 {
-    public class PngTest
+    public class SvgTest
     {
         [Fact]
-        private void PngImage()
+        private void SvgImage()
         {
-            var qrCode = EncodeText("The quick brown fox jumps over the lazy dog", Ecc.High);
-            using (var bitmap = qrCode.ToBitmap(3, 4))
-            {
-                Assert.Equal(135, bitmap.Width);
-                Assert.Equal(135, bitmap.Height);
+            var qrCode = EncodeText("At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.", Ecc.Medium);
+            string svg = qrCode.ToSvgString(0);
 
-                bitmap.Save("qrcode.png", ImageFormat.Png);
-            }
+            Assert.StartsWith("<?xml", svg);
+            Assert.Contains("\"0 0 69 69\"", svg); // view box
+
+            File.WriteAllText("qrcode.svg", svg, Encoding.UTF8);
         }
     }
 }

--- a/dotnet/QrCodeGeneratorTest/TestHelper.cs
+++ b/dotnet/QrCodeGeneratorTest/TestHelper.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * QR Code generator library (.NET)
+ * QR code generator library (.NET)
  * 
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library

--- a/dotnet/QrCodeGeneratorTest/TestHelper.cs
+++ b/dotnet/QrCodeGeneratorTest/TestHelper.cs
@@ -1,0 +1,47 @@
+﻿/* 
+ * QR Code generator library (.NET)
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+
+namespace Io.Nayuki.QrCodeGen.Test
+{
+    internal class TestHelper
+    {
+        internal static string[] ToStringArray(QrCode qrCode)
+        {
+            int size = qrCode.Size;
+            string[] result = new string[size];
+
+            for (int y = 0; y < size; y++)
+            {
+                char[] row = new char[size];
+                for (int x = 0; x < size; x++)
+                {
+                    row[x] = qrCode.GetModule(x, y) ? 'X' : ' ';
+                }
+                result[y] = new string(row);
+            }
+
+            return result;
+        }
+    }
+}

--- a/dotnet/QrCodeGeneratorTest/TestHelper.cs
+++ b/dotnet/QrCodeGeneratorTest/TestHelper.cs
@@ -22,7 +22,7 @@
  */
 
 
-namespace Io.Nayuki.QrCodeGen.Test
+namespace IO.Nayuki.QrCodeGen.Test
 {
     internal class TestHelper
     {


### PR DESCRIPTION
I've ported the Java version of the library to .NET. It provides the same features as the Java library (incl. raster images, SVG, Kanji, optimized segments).

The projects consists of three subprojects:

1. The library itself
2. A test project (using xUnit)
3. The demo application

The project/solution can be opened with Visual Studio 2017 Community. Or you can be up and running with Visual Studio Code on the Mac in 10 minutes.

The library is built for .NET Standard 2.0. So it runs on .NET Core, .NET Framework, UWP, Mono, Xamarin etc.

The test cases have been built with the Java version to ensure the .NET library produces exactly the same output as the Java version.

The implementation does not use a *BitBuffer* class. Instead, it uses the built-in *BitArray* with two helper methods.

The documentation is as complete as the one for the Java version. The HTML files can be built with `docfx QrCodeGenerator/docfx/docfx.json`. For a first preview, I've built and uploaded them to https://codecrete.net/QrCodeGen.NET/api/index.html.

If you create a NuGet account (similar to Maven Central), you can *pack* the library and upload it to NuGet. Or you can automate the publication with the following commands:

```
cd dotnet\QrCodeGenerator
dotnet pack --configuration Release
nuget push bin\Release\Io.Nayuki.QrCodeGen.1.4.1.nupkg secret-api-key-secret -Source https://api.nuget.org/v3/index.json
```

I do have the exactly same test cases for Java. It you're interested in them, I can create a pull request for them. 