### PR TITLE
Adds CMakeLists.txt for C++ version

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(libqrcodegen)
+
+add_library(qrcodegen STATIC 
+    BitBuffer.cpp QrSegment.cpp QrCode.cpp)
+
+target_include_directories(qrcodegen PUBLIC 
+    ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
It is good to have CMake compatibility. Demos can be build without
it, but it will improve usability because with CMakeFiles.txt you
just have to specify library path and link library, e.g.
```
add_subdirecory(libs/QR-Code-generator/cpp)
...
target_link_libraries(binary qrcodegen)
```