### PR TITLE
Support for no_std

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,3 +9,8 @@ readme = "Readme.markdown"
 keywords = ["qr-code", "barcode", "encoder", "image"]
 categories = ["encoding", "multimedia::images"]
 license = "MIT"
+
+[features]
+default = ["std"]
+std = []
+alloc = [] # required for nightly compiler before 1.36.0

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -79,7 +79,22 @@
 //!     }
 //! }
 //! ```
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 
+#![cfg(not(feature = "std"))]
+#[macro_use] extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::i32;
+    pub use core::cmp;
+    pub use core::fmt;
+    pub use alloc::collections;
+}
 
 /*---- QrCode functionality ----*/
 
@@ -1274,6 +1289,7 @@ impl BitBuffer {
 #[derive(Debug, Clone)]
 pub struct DataTooLong(String);
 
+#[cfg(feature = "std")]
 impl std::error::Error for DataTooLong {
 	fn description(&self) -> &str {
 		&self.0

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -801,9 +801,11 @@ impl QrCode {
 /*---- Cconstants and tables ----*/
 
 /// The minimum version number supported in the QR Code Model 2 standard.
+#[allow(non_upper_case_globals)]
 pub const QrCode_MIN_VERSION: Version = Version( 1);
 
 /// The maximum version number supported in the QR Code Model 2 standard.
+#[allow(non_upper_case_globals)]
 pub const QrCode_MAX_VERSION: Version = Version(40);
 
 


### PR DESCRIPTION
Hello @nayuki!

Thank you for qrencode crate!

I have added some `cfg`s that allow this crate to be compiled for no_std (no OS) environment. It would be nice if you merge this PR.

Let me know if you need some changes before merge.

Thanks in advance!