### PR TITLE
Make it possible to compile with GNU dialect of ISO C90

### DIFF
--- a/c/qrcodegen.c
+++ b/c/qrcodegen.c
@@ -211,7 +211,7 @@ bool qrcodegen_encodeSegmentsAdvanced(const struct qrcodegen_Segment segs[], siz
 	// Find the minimal version number to use
 	int version, dataUsedBits;
 	int i, j;
-    size_t k;
+    	size_t k;
 	uint8_t padByte;	
 	for (version = minVersion; ; version++) {
 		int dataCapacityBits = getNumDataCodewords(version, ecl) * 8;  // Number of data bits available


### PR DESCRIPTION
To solve and Closes: #59
GNU dialect of ISO C90 is default for C code compile mode when compiling arm-brcm-linux-gnueabi-gcc and it doesn't support variable declaration in for loop .