### PR TITLE
Corrected data types to eliminate C++ sign-warnings

### DIFF
--- a/cpp/BitBuffer.cpp
+++ b/cpp/BitBuffer.cpp
@@ -31,11 +31,11 @@ BitBuffer::BitBuffer()
 	: std::vector<bool>() {}
 
 
-void BitBuffer::appendBits(std::uint32_t val, int len) {
-	if (len < 0 || len > 31 || val >> len != 0)
+void BitBuffer::appendBits(std::size_t val, std::size_t len) {
+	if (len > 31 || val >> len != 0) // len < 0 does not need to be checked, because std::size_t is guaranteed to be unsigned
 		throw std::domain_error("Value out of range");
-	for (int i = len - 1; i >= 0; i--)  // Append bit by bit
-		this->push_back(((val >> i) & 1) != 0);
+	for (std::size_t i = len; i > 0; i--)  // Append bit by bit
+		this->push_back(((val >> (i-1)) & 1) != 0);
 }
 
 }

--- a/cpp/BitBuffer.hpp
+++ b/cpp/BitBuffer.hpp
@@ -45,7 +45,7 @@ class BitBuffer final : public std::vector<bool> {
 	
 	// Appends the given number of low-order bits of the given value
 	// to this buffer. Requires 0 <= len <= 31 and val < 2^len.
-	public: void appendBits(std::uint32_t val, int len);
+	public: void appendBits(std::size_t val, std::size_t len);
 	
 };
 

--- a/cpp/QrCode.cpp
+++ b/cpp/QrCode.cpp
@@ -235,9 +235,9 @@ void QrCode::drawFunctionPatterns() {
 	
 	// Draw numerous alignment patterns
 	const vector<int> alignPatPos = getAlignmentPatternPositions();
-	int numAlign = alignPatPos.size();
-	for (int i = 0; i < numAlign; i++) {
-		for (int j = 0; j < numAlign; j++) {
+	std::size_t numAlign = alignPatPos.size();
+	for (std::size_t i = 0; i < numAlign; i++) {
+		for (std::size_t j = 0; j < numAlign; j++) {
 			// Don't draw on the three finder corners
 			if (!((i == 0 && j == 0) || (i == 0 && j == numAlign - 1) || (i == numAlign - 1 && j == 0)))
 				drawAlignmentPattern(alignPatPos.at(i), alignPatPos.at(j));
@@ -346,7 +346,8 @@ vector<uint8_t> QrCode::addEccAndInterleave(const vector<uint8_t> &data) const {
 	// Split data into blocks and append ECC to each block
 	vector<vector<uint8_t> > blocks;
 	const vector<uint8_t> rsDiv = reedSolomonComputeDivisor(blockEccLen);
-	for (int i = 0, k = 0; i < numBlocks; i++) {
+	std::size_t k = 0;
+	for (int i = 0; i < numBlocks; i++) {
 		vector<uint8_t> dat(data.cbegin() + k, data.cbegin() + (k + shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1)));
 		k += dat.size();
 		const vector<uint8_t> ecc = reedSolomonComputeRemainder(dat, rsDiv);

--- a/cpp/QrSegment.cpp
+++ b/cpp/QrSegment.cpp
@@ -1,9 +1,9 @@
-/* 
+/*
  * QR Code generator library (C++)
- * 
+ *
  * Copyright (c) Project Nayuki. (MIT License)
  * https://www.nayuki.io/page/qr-code-generator-library
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
@@ -94,7 +94,7 @@ QrSegment QrSegment::makeNumeric(const char *digits) {
 
 QrSegment QrSegment::makeAlphanumeric(const char *text) {
 	BitBuffer bb;
-	int accumData = 0;
+	std::size_t accumData = 0;
 	int accumCount = 0;
 	int charCount = 0;
 	for (; *text != '\0'; text++, charCount++) {


### PR DESCRIPTION
Hi @nayuki and hello to all,

While compiling the C++ code with different compilers, I encountered some warnings concerning unsigned and signed data types. I replaced those data types with std::size_t to eliminate the following warnings:
* clang7: comparison of integers of different signs: 'int' and 'std::size_t'
* Microsoft cl 19.16.27030.1 warnings:
 * C4267: conversion from 'size_t' to 'int', possible loss of data
 * C4244: conversion from '__int64' to 'int', possible loss of data
As a direct consequence I also changed the loop in BitBuffer::appendBits() to prevent an underflow.

Just drop me a note if you need further information regarding this pull request.

thx & kind regards
christian