### PR TITLE
Honor LDFLAGS when building executables.

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -65,11 +65,11 @@ clean:
 
 # Executable files
 %: %.o $(LIBFILE)
-	$(CC) $(CFLAGS) -o $@ $< -L . -l $(LIB)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -L . -l $(LIB)
 
 # Special executable
 qrcodegen-test: qrcodegen-test.c $(LIBOBJ:%.o=%.c)
-	$(CC) $(CFLAGS) -DQRCODEGEN_TEST -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -DQRCODEGEN_TEST -o $@ $^
 
 # The library
 $(LIBFILE): $(LIBOBJ)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -65,7 +65,7 @@ clean:
 
 # Executable files
 %: %.o $(LIBFILE)
-	$(CXX) $(CXXFLAGS) -o $@ $< -L . -l $(LIB)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< -L . -l $(LIB)
 
 # The library
 $(LIBFILE): $(LIBOBJ)


### PR DESCRIPTION
This fixes e.g. RELRO builds which need LDFLAGS (passed in from the outside).