### PR TITLE
Rust: Fixed the 'encode_segments_advanced' documentation example code

### DIFF
--- a/rust/Readme.markdown
+++ b/rust/Readme.markdown
@@ -38,6 +38,8 @@ Examples
     use qrcodegen::QrCode;
     use qrcodegen::QrCodeEcc;
     use qrcodegen::QrSegment;
+    use qrcodegen::Version;
+    use qrcodegen::Mask;
     
     // Simple operation
     let qr = QrCode::encode_text("Hello, world!",
@@ -48,7 +50,13 @@ Examples
     let chrs: Vec<char> = "3141592653589793238462643383".chars().collect();
     let segs = QrSegment::make_segments(&chrs);
     let qr = QrCode::encode_segments_advanced(
-        &segs, QrCodeEcc::High, 5, 5, Some(Mask::new(2)), false).unwrap();
+        &segs,
+        QrCodeEcc::High,
+        Version::new(5),
+        Version::new(5),
+        Some(Mask::new(2)),
+        false,
+    ).unwrap();
     for y in 0 .. qr.size() {
         for x in 0 .. qr.size() {
             (... paint qr.get_module(x, y) ...)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,6 +57,8 @@
 //! use qrcodegen::QrCode;
 //! use qrcodegen::QrCodeEcc;
 //! use qrcodegen::QrSegment;
+//! use qrcodegen::Version;
+//! use qrcodegen::Mask;
 //! ```
 //! 
 //! Simple operation:
@@ -73,7 +75,13 @@
 //! let chrs: Vec<char> = "3141592653589793238462643383".chars().collect();
 //! let segs = QrSegment::make_segments(&chrs);
 //! let qr = QrCode::encode_segments_advanced(
-//!     &segs, QrCodeEcc::High, 5, 5, Some(Mask::new(2)), false).unwrap();
+//!     &segs,
+//!     QrCodeEcc::High,
+//!     Version::new(5),
+//!     Version::new(5),
+//!     Some(Mask::new(2)),
+//!     false
+//! ).unwrap();
 //! for y in 0 .. qr.size() {
 //!     for x in 0 .. qr.size() {
 //!         (... paint qr.get_module(x, y) ...)


### PR DESCRIPTION
Fixes the example code for the `encode_segments_advanced`, that was not working due to `encode_segments_advanced` accepting `Version` as 3rd and 4th arguments, but `i32` being provided.

Also added an import for the `qrcodegen::Mask`.

As an alternative `encode_segments_advanced`  could be rewritten to accept `Into<Version>` as 3rd and 4th arguments and implement `From<i32> for Version`, so `5` could be passed, but I do not know if this is an acceptable change for this project

