### PR TITLE
C++ version: use const-reference in QrSegment ctor

### DIFF
--- a/cpp/QrCode.cpp
+++ b/cpp/QrCode.cpp
@@ -156,7 +156,7 @@ QrSegment QrSegment::makeEci(long assignVal) {
 }
 
 
-QrSegment::QrSegment(Mode md, int numCh, const std::vector<bool> &dt) :
+QrSegment::QrSegment(const Mode &md, int numCh, const std::vector<bool> &dt) :
 		mode(md),
 		numChars(numCh),
 		data(dt) {
@@ -165,7 +165,7 @@ QrSegment::QrSegment(Mode md, int numCh, const std::vector<bool> &dt) :
 }
 
 
-QrSegment::QrSegment(Mode md, int numCh, std::vector<bool> &&dt) :
+QrSegment::QrSegment(const Mode &md, int numCh, std::vector<bool> &&dt) :
 		mode(md),
 		numChars(numCh),
 		data(std::move(dt)) {

--- a/cpp/QrCode.hpp
+++ b/cpp/QrCode.hpp
@@ -170,7 +170,7 @@ class QrSegment final {
 	 * The character count (numCh) must agree with the mode and the bit buffer length,
 	 * but the constraint isn't checked. The given bit buffer is copied and stored.
 	 */
-	public: QrSegment(Mode md, int numCh, const std::vector<bool> &dt);
+	public: QrSegment(const Mode &md, int numCh, const std::vector<bool> &dt);
 	
 	
 	/* 
@@ -178,7 +178,7 @@ class QrSegment final {
 	 * The character count (numCh) must agree with the mode and the bit buffer length,
 	 * but the constraint isn't checked. The given bit buffer is moved and stored.
 	 */
-	public: QrSegment(Mode md, int numCh, std::vector<bool> &&dt);
+	public: QrSegment(const Mode &md, int numCh, std::vector<bool> &&dt);
 	
 	
 	/*---- Methods ----*/


### PR DESCRIPTION
Fixes a small performance issue. `Mode` was being passed by value (copied) - this change uses a reference.