### PR TITLE
C++ version: removed impossible validation

### DIFF
--- a/cpp/QrCode.cpp
+++ b/cpp/QrCode.cpp
@@ -349,7 +349,7 @@ QrCode::QrCode(int ver, Ecc ecl, const vector<uint8_t> &dataCodewords, int msk) 
 			applyMask(i);  // Undoes the mask due to XOR
 		}
 	}
-	if (msk < 0 || msk > 7)
+	if (msk < 0)
 		throw std::logic_error("Assertion error");
 	this->mask = msk;
 	applyMask(msk);  // Apply the final choice of mask


### PR DESCRIPTION
There are no code paths that can lead to `msk > 7`.