### PR TITLE
Fix C compilation with -Werror=unused-parameter and without asserts.

### DIFF
--- a/c/qrcodegen.c
+++ b/c/qrcodegen.c
@@ -712,6 +712,7 @@ static long getPenaltyScore(const uint8_t qrcode[]) {
 // Can only be called immediately after a white run is added, and
 // returns either 0, 1, or 2. A helper function for getPenaltyScore().
 static int finderPenaltyCountPatterns(const int runHistory[7], int qrsize) {
+	(void)qrsize;
 	int n = runHistory[1];
 	assert(n <= qrsize * 3);
 	bool core = n > 0 && runHistory[2] == n && runHistory[3] == n * 3 && runHistory[4] == n && runHistory[5] == n;


### PR DESCRIPTION
Fixes builds with `-Werror=unused-parameter` and without asserts:
```
../vendor/QR-Code-generator/c/qrcodegen.c: In function 'finderPenaltyCountPatterns':
../vendor/QR-Code-generator/c/qrcodegen.c:714:68: error: unused parameter 'qrsize' [-Werror=unused-parameter]
  714 | static int finderPenaltyCountPatterns(const int runHistory[7], int qrsize) {
      |                                                                ~~~~^~~~~~
cc1: all warnings being treated as errors
```