### PR TITLE
ignore doc-tests that don't seem to be intended to be compiled and run

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -64,7 +64,7 @@
 //! 
 //! Simple operation:
 //! 
-//! ```
+//! ```ignore
 //! let qr = QrCode::encode_text("Hello, world!",
 //!     QrCodeEcc::Medium).unwrap();
 //! let svg = to_svg_string(&qr, 4);  // See qrcodegen-demo
@@ -72,7 +72,7 @@
 //! 
 //! Manual operation:
 //! 
-//! ```
+//! ```ignore
 //! let text: &str = "3141592653589793238462643383";
 //! let segs = QrSegment::make_segments(text);
 //! let qr = QrCode::encode_segments_advanced(&segs, QrCodeEcc::High,


### PR DESCRIPTION
Without this patch we get these compilation errors when running `cargo test`

```
$ cargo test
   Compiling qrcodegen v1.8.0 (/home/capitol/project/QR-Code-generator/rust)
warning: unnecessary parentheses around block return value
   --> src/lib.rs:842:3
    |
842 |         ( i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
    |         ^^
843 |         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n))
    |                                                          ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
842 ~         i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
843 ~         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n)
    |

warning: `qrcodegen` (lib) generated 1 warning
warning: `qrcodegen` (lib test) generated 1 warning (1 duplicate)
    Finished test [unoptimized + debuginfo] target(s) in 0.26s
     Running unittests src/lib.rs (target/debug/deps/qrcodegen-c7dbb02aad6a773c)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests qrcodegen
warning: unnecessary parentheses around block return value
   --> /home/capitol/project/QR-Code-generator/rust/src/lib.rs:842:3
    |
842 |         ( i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
    |         ^^
843 |         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n))
    |                                                          ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
842 ~         i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
843 ~         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n)
    |

warning: 1 warning emitted


running 3 tests
test src/lib.rs - (line 67) ... FAILED
test src/lib.rs - (line 75) ... FAILED
test src/lib.rs - (line 56) ... ok

failures:

---- src/lib.rs - (line 67) stdout ----
error[E0433]: failed to resolve: use of undeclared type `QrCodeEcc`
 --> src/lib.rs:69:5
  |
5 |     QrCodeEcc::Medium).unwrap();
  |     ^^^^^^^^^ use of undeclared type `QrCodeEcc`

error[E0433]: failed to resolve: use of undeclared type `QrCode`
 --> src/lib.rs:68:10
  |
4 | let qr = QrCode::encode_text("Hello, world!",
  |          ^^^^^^ not found in this scope
  |
help: consider importing this struct
  |
2 | use qrcodegen::QrCode;
  |

error[E0425]: cannot find function `to_svg_string` in this scope
 --> src/lib.rs:70:11
  |
6 | let svg = to_svg_string(&qr, 4);  // See qrcodegen-demo
  |           ^^^^^^^^^^^^^ not found in this scope

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0425, E0433.
For more information about an error, try `rustc --explain E0425`.
Couldn't compile the test.
---- src/lib.rs - (line 75) stdout ----
error: unexpected token: `...`
 --> src/lib.rs:82:10
  |
9 |         (... paint qr.get_module(x, y) ...)
  |          ^^^
  |
help: use `..` for an exclusive range
  |
9 |         (.. paint qr.get_module(x, y) ...)
  |          ~~
help: or `..=` for an inclusive range
  |
9 |         (..= paint qr.get_module(x, y) ...)
  |          ~~~

error: unexpected token: `...`
 --> src/lib.rs:82:40
  |
9 |         (... paint qr.get_module(x, y) ...)
  |                                        ^^^
  |
help: use `..` for an exclusive range
  |
9 |         (... paint qr.get_module(x, y) ..)
  |                                        ~~
help: or `..=` for an inclusive range
  |
9 |         (... paint qr.get_module(x, y) ..=)
  |                                        ~~~

error[E0586]: inclusive range with no end
 --> src/lib.rs:82:40
  |
9 |         (... paint qr.get_module(x, y) ...)
  |                                        ^^^ help: use `..` instead
  |
  = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)

error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found `qr`
 --> src/lib.rs:82:20
  |
9 |         (... paint qr.get_module(x, y) ...)
  |                   -^^ expected one of 8 possible tokens
  |                   |
  |                   help: missing `,`

error[E0433]: failed to resolve: use of undeclared type `QrSegment`
 --> src/lib.rs:77:12
  |
4 | let segs = QrSegment::make_segments(text);
  |            ^^^^^^^^^ use of undeclared type `QrSegment`

error[E0433]: failed to resolve: use of undeclared type `QrCode`
 --> src/lib.rs:78:10
  |
5 | let qr = QrCode::encode_segments_advanced(&segs, QrCodeEcc::High,
  |          ^^^^^^ use of undeclared type `QrCode`

error[E0433]: failed to resolve: use of undeclared type `QrCodeEcc`
 --> src/lib.rs:78:50
  |
5 | let qr = QrCode::encode_segments_advanced(&segs, QrCodeEcc::High,
  |                                                  ^^^^^^^^^ use of undeclared type `QrCodeEcc`

error[E0433]: failed to resolve: use of undeclared type `Version`
 --> src/lib.rs:79:5
  |
6 |     Version::new(5), Version::new(5), Some(Mask::new(2)), false).unwrap();
  |     ^^^^^^^ use of undeclared type `Version`

error[E0433]: failed to resolve: use of undeclared type `Version`
 --> src/lib.rs:79:22
  |
6 |     Version::new(5), Version::new(5), Some(Mask::new(2)), false).unwrap();
  |                      ^^^^^^^ use of undeclared type `Version`

error[E0433]: failed to resolve: use of undeclared type `Mask`
 --> src/lib.rs:79:44
  |
6 |     Version::new(5), Version::new(5), Some(Mask::new(2)), false).unwrap();
  |                                            ^^^^ not found in this scope
  |
help: consider importing this struct
  |
2 | use std::simd::Mask;
  |

error[E0425]: cannot find value `paint` in this scope
 --> src/lib.rs:82:14
  |
9 |         (... paint qr.get_module(x, y) ...)
  |              ^^^^^ not found in this scope

error: aborting due to 11 previous errors

Some errors have detailed explanations: E0425, E0433, E0586.
For more information about an error, try `rustc --explain E0425`.
Couldn't compile the test.

failures:
    src/lib.rs - (line 67)
    src/lib.rs - (line 75)

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

error: test failed, to rerun pass '--doc'
```