### PR TITLE
Changed Version::new to const in Rust code.

### DIFF
--- a/rust-no-heap/src/lib.rs
+++ b/rust-no-heap/src/lib.rs
@@ -1431,13 +1431,13 @@ impl Version {
 	/// Creates a version object from the given number.
 	/// 
 	/// Panics if the number is outside the range [1, 40].
-	pub fn new(ver: u8) -> Self {
-		assert!((Version::MIN.value() ..= Version::MAX.value()).contains(&ver), "Version number out of range");
+	pub const fn new(ver: u8) -> Self {
+		assert!((Version::MIN.value() <= ver && ver <= Version::MAX.value()), "Version number out of range");
 		Self(ver)
 	}
 	
 	/// Returns the value, which is in the range [1, 40].
-	pub fn value(self) -> u8 {
+	pub const fn value(self) -> u8 {
 		self.0
 	}
 	

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1264,13 +1264,13 @@ impl Version {
 	/// Creates a version object from the given number.
 	/// 
 	/// Panics if the number is outside the range [1, 40].
-	pub fn new(ver: u8) -> Self {
-		assert!((Version::MIN.value() ..= Version::MAX.value()).contains(&ver), "Version number out of range");
+	pub const fn new(ver: u8) -> Self {
+		assert!((Version::MIN.value() <= ver && ver <= Version::MAX.value()), "Version number out of range");
 		Self(ver)
 	}
 	
 	/// Returns the value, which is in the range [1, 40].
-	pub fn value(self) -> u8 {
+	pub const fn value(self) -> u8 {
 		self.0
 	}
 }


### PR DESCRIPTION
Awesome library, appreciate the rust-no-heap version, it's working great! I'd like to define local max version, since anything larger doesn't fit on the device screen:

```
const QR_MAX_VERSION: Version = Version::new(9);
...
let mut outbuffer = [0u8; QR_MAX_VERSION.buffer_len()];
let mut tempbuffer = [0u8; QR_MAX_VERSION.buffer_len()];
```

For that it would be useful if `Version::new` was const. Unforunately it's not only a matter of adding the keyword since `RangeInclusive::contains` is not (yet?) const.