### PR TITLE
Tweaked Rust code to avoid unused parentheses warning.

### DIFF
--- a/rust-no-heap/src/lib.rs
+++ b/rust-no-heap/src/lib.rs
@@ -965,8 +965,8 @@ impl FinderPenalty {
 		let n = rh[1];
 		debug_assert!(n <= self.qr_size * 3);
 		let core = n > 0 && rh[2] == n && rh[3] == n * 3 && rh[4] == n && rh[5] == n;
-		( i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
-		+ i32::from(core && rh[6] >= n * 4 && rh[0] >= n))
+		i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
+		+ i32::from(core && rh[6] >= n * 4 && rh[0] >= n)
 	}
 	
 	

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -839,8 +839,8 @@ impl FinderPenalty {
 		let n = rh[1];
 		debug_assert!(n <= self.qr_size * 3);
 		let core = n > 0 && rh[2] == n && rh[3] == n * 3 && rh[4] == n && rh[5] == n;
-		( i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
-		+ i32::from(core && rh[6] >= n * 4 && rh[0] >= n))
+		i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
+		+ i32::from(core && rh[6] >= n * 4 && rh[0] >= n)
 	}
 	
 	


### PR DESCRIPTION
Fixes the following compiler warning:
```
warning: unnecessary parentheses around block return value
   --> /home/mmilata/work/trezor-firmware/core/vendor/QR-Code-generator/rust-no-heap/src/lib.rs:968:3
    |
968 |         ( i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
    |         ^^
969 |         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n))
    |                                                          ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
968 ~         i32::from(core && rh[0] >= n * 4 && rh[6] >= n)
969 ~         + i32::from(core && rh[6] >= n * 4 && rh[0] >= n)
```