### PR TITLE
fix(rust): make noheap version have different name so it's easier for Cargo…

### DIFF
--- a/rust-no-heap/Cargo.toml
+++ b/rust-no-heap/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "qrcodegen"
+name = "qrcodegen-noheap"
 version = "1.8.0"
 authors = ["Project Nayuki"]
 description = "High-quality QR Code generator library"


### PR DESCRIPTION
… to be found

See this discussion

https://github.com/rust-lang/cargo/issues/11858

With this tiny correction, this crate could indeed be used. I also think you should publish this masterpiece on crates alongside with heaped version if you do not want to replace one with the other.