### PR TITLE
Fix portability problem with ar(1) on macOS.

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -73,7 +73,7 @@ qrcodegen-test: qrcodegen-test.c $(LIBOBJ:%.o=%.c)
 
 # The library
 $(LIBFILE): $(LIBOBJ)
-	$(AR) -crs $@ -- $^
+	$(AR) -crs $@ $^
 
 # Object files
 %.o: %.c .deps/timestamp


### PR DESCRIPTION
macOS ar(1) does not support '--'.

Fixes #43, #95, #170.