### PR TITLE
Fix typo

### DIFF
--- a/c/qrcodegen.c
+++ b/c/qrcodegen.c
@@ -799,7 +799,7 @@ testable void setModuleUnbounded(uint8_t qrcode[], int x, int y, bool isDark) {
 }
 
 
-// Returns true iff the i'th bit of x is set to 1. Requires x >= 0 and 0 <= i <= 14.
+// Returns true if the i'th bit of x is set to 1. Requires x >= 0 and 0 <= i <= 14.
 static bool getBit(int x, int i) {
 	return ((x >> i) & 1) != 0;
 }

--- a/c/qrcodegen.h
+++ b/c/qrcodegen.h
@@ -156,7 +156,7 @@ struct qrcodegen_Segment {
  * Requires 1 <= minVersion <= maxVersion <= 40.
  * 
  * The smallest possible QR Code version within the given range is automatically
- * chosen for the output. Iff boostEcl is true, then the ECC level of the result
+ * chosen for the output. If boostEcl is true, then the ECC level of the result
  * may be higher than the ecl argument if it can be done without increasing the
  * version. The mask is either between qrcodegen_Mask_0 to 7 to force that mask, or
  * qrcodegen_Mask_AUTO to automatically choose an appropriate mask (which may be slow).
@@ -196,7 +196,7 @@ bool qrcodegen_encodeText(const char *text, uint8_t tempBuffer[], uint8_t qrcode
  * Requires 1 <= minVersion <= maxVersion <= 40.
  * 
  * The smallest possible QR Code version within the given range is automatically
- * chosen for the output. Iff boostEcl is true, then the ECC level of the result
+ * chosen for the output. If boostEcl is true, then the ECC level of the result
  * may be higher than the ecl argument if it can be done without increasing the
  * version. The mask is either between qrcodegen_Mask_0 to 7 to force that mask, or
  * qrcodegen_Mask_AUTO to automatically choose an appropriate mask (which may be slow).
@@ -272,7 +272,7 @@ bool qrcodegen_encodeSegments(const struct qrcodegen_Segment segs[], size_t len,
  * Requires 1 <= minVersion <= maxVersion <= 40.
  * 
  * The smallest possible QR Code version within the given range is automatically
- * chosen for the output. Iff boostEcl is true, then the ECC level of the result
+ * chosen for the output. If boostEcl is true, then the ECC level of the result
  * may be higher than the ecl argument if it can be done without increasing the
  * version. The mask is either between qrcodegen_Mask_0 to 7 to force that mask, or
  * qrcodegen_Mask_AUTO to automatically choose an appropriate mask (which may be slow).
@@ -305,14 +305,14 @@ bool qrcodegen_encodeSegmentsAdvanced(const struct qrcodegen_Segment segs[], siz
 
 /* 
  * Tests whether the given string can be encoded as a segment in numeric mode.
- * A string is encodable iff each character is in the range 0 to 9.
+ * A string is encodable if each character is in the range 0 to 9.
  */
 bool qrcodegen_isNumeric(const char *text);
 
 
 /* 
  * Tests whether the given string can be encoded as a segment in alphanumeric mode.
- * A string is encodable iff each character is in the following set: 0 to 9, A to Z
+ * A string is encodable if each character is in the following set: 0 to 9, A to Z
  * (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
  */
 bool qrcodegen_isAlphanumeric(const char *text);

--- a/cpp/qrcodegen.hpp
+++ b/cpp/qrcodegen.hpp
@@ -134,14 +134,14 @@ class QrSegment final {
 	
 	/* 
 	 * Tests whether the given string can be encoded as a segment in numeric mode.
-	 * A string is encodable iff each character is in the range 0 to 9.
+	 * A string is encodable if each character is in the range 0 to 9.
 	 */
 	public: static bool isNumeric(const char *text);
 	
 	
 	/* 
 	 * Tests whether the given string can be encoded as a segment in alphanumeric mode.
-	 * A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	 * A string is encodable if each character is in the following set: 0 to 9, A to Z
 	 * (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	 */
 	public: static bool isAlphanumeric(const char *text);
@@ -279,7 +279,7 @@ class QrCode final {
 	/* 
 	 * Returns a QR Code representing the given segments with the given encoding parameters.
 	 * The smallest possible QR Code version within the given range is automatically
-	 * chosen for the output. Iff boostEcl is true, then the ECC level of the result
+	 * chosen for the output. If boostEcl is true, then the ECC level of the result
 	 * may be higher than the ecl argument if it can be done without increasing the
 	 * version. The mask number is either between 0 to 7 (inclusive) to force that
 	 * mask, or -1 to automatically choose an appropriate mask (which may be slow).
@@ -382,7 +382,7 @@ class QrCode final {
 	
 	
 	// Draws two copies of the version bits (with its own error correction code),
-	// based on this object's version field, iff 7 <= version <= 40.
+	// based on this object's version field, if 7 <= version <= 40.
 	private: void drawVersion();
 	
 	
@@ -478,7 +478,7 @@ class QrCode final {
 	private: void finderPenaltyAddHistory(int currentRunLength, std::array<int,7> &runHistory) const;
 	
 	
-	// Returns true iff the i'th bit of x is set to 1.
+	// Returns true if the i'th bit of x is set to 1.
 	private: static bool getBit(long x, int i);
 	
 	

--- a/java-fast/io/nayuki/fastqrcodegen/QrCode.java
+++ b/java-fast/io/nayuki/fastqrcodegen/QrCode.java
@@ -119,7 +119,7 @@ public final class QrCode {
 	/**
 	 * Returns a QR Code representing the specified segments with the specified encoding parameters.
 	 * The smallest possible QR Code version within the specified range is automatically
-	 * chosen for the output. Iff boostEcl is {@code true}, then the ECC level of the
+	 * chosen for the output. If boostEcl is {@code true}, then the ECC level of the
 	 * result may be higher than the ecl argument if it can be done without increasing
 	 * the version. The mask number is either between 0 to 7 (inclusive) to force that
 	 * mask, or &#x2212;1 to automatically choose an appropriate mask (which may be slow).

--- a/java-fast/io/nayuki/fastqrcodegen/QrSegment.java
+++ b/java-fast/io/nayuki/fastqrcodegen/QrSegment.java
@@ -179,9 +179,9 @@ public final class QrSegment {
 	
 	/**
 	 * Tests whether the specified string can be encoded as a segment in numeric mode.
-	 * A string is encodable iff each character is in the range 0 to 9.
+	 * A string is encodable if each character is in the range 0 to 9.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the range 0 to 9.
+	 * @return {@code true} if each character is in the range 0 to 9.
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeNumeric(String)
 	 */
@@ -197,10 +197,10 @@ public final class QrSegment {
 	
 	/**
 	 * Tests whether the specified string can be encoded as a segment in alphanumeric mode.
-	 * A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	 * A string is encodable if each character is in the following set: 0 to 9, A to Z
 	 * (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the alphanumeric mode character set
+	 * @return {@code true} if each character is in the alphanumeric mode character set
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeAlphanumeric(String)
 	 */

--- a/java-fast/io/nayuki/fastqrcodegen/QrSegmentAdvanced.java
+++ b/java-fast/io/nayuki/fastqrcodegen/QrSegmentAdvanced.java
@@ -271,7 +271,7 @@ public final class QrSegmentAdvanced {
 	 * Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
 	 * more extensive Chinese hanzi}.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the kanji mode character set
+	 * @return {@code true} if each character is in the kanji mode character set
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeKanji(String)
 	 */

--- a/java-fast/io/nayuki/fastqrcodegen/QrTemplate.java
+++ b/java-fast/io/nayuki/fastqrcodegen/QrTemplate.java
@@ -112,7 +112,7 @@ final class QrTemplate {
 	
 	
 	// Draws two copies of the version bits (with its own error correction code),
-	// based on this object's version field, iff 7 <= version <= 40.
+	// based on this object's version field, if 7 <= version <= 40.
 	private void drawVersion() {
 		if (version < 7)
 			return;

--- a/java/src/main/java/io/nayuki/qrcodegen/QrCode.java
+++ b/java/src/main/java/io/nayuki/qrcodegen/QrCode.java
@@ -119,7 +119,7 @@ public final class QrCode {
 	/**
 	 * Returns a QR Code representing the specified segments with the specified encoding parameters.
 	 * The smallest possible QR Code version within the specified range is automatically
-	 * chosen for the output. Iff boostEcl is {@code true}, then the ECC level of the
+	 * chosen for the output. If boostEcl is {@code true}, then the ECC level of the
 	 * result may be higher than the ecl argument if it can be done without increasing
 	 * the version. The mask number is either between 0 to 7 (inclusive) to force that
 	 * mask, or &#x2212;1 to automatically choose an appropriate mask (which may be slow).
@@ -366,7 +366,7 @@ public final class QrCode {
 	
 	
 	// Draws two copies of the version bits (with its own error correction code),
-	// based on this object's version field, iff 7 <= version <= 40.
+	// based on this object's version field, if 7 <= version <= 40.
 	private void drawVersion() {
 		if (version < 7)
 			return;
@@ -748,7 +748,7 @@ public final class QrCode {
 	}
 	
 	
-	// Returns true iff the i'th bit of x is set to 1.
+	// Returns true if the i'th bit of x is set to 1.
 	static boolean getBit(int x, int i) {
 		return ((x >>> i) & 1) != 0;
 	}

--- a/java/src/main/java/io/nayuki/qrcodegen/QrSegment.java
+++ b/java/src/main/java/io/nayuki/qrcodegen/QrSegment.java
@@ -164,9 +164,9 @@ public final class QrSegment {
 	
 	/**
 	 * Tests whether the specified string can be encoded as a segment in numeric mode.
-	 * A string is encodable iff each character is in the range 0 to 9.
+	 * A string is encodable if each character is in the range 0 to 9.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the range 0 to 9.
+	 * @return {@code true} if each character is in the range 0 to 9.
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeNumeric(CharSequence)
 	 */
@@ -177,10 +177,10 @@ public final class QrSegment {
 	
 	/**
 	 * Tests whether the specified string can be encoded as a segment in alphanumeric mode.
-	 * A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	 * A string is encodable if each character is in the following set: 0 to 9, A to Z
 	 * (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the alphanumeric mode character set
+	 * @return {@code true} if each character is in the alphanumeric mode character set
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeAlphanumeric(CharSequence)
 	 */

--- a/java/src/main/java/io/nayuki/qrcodegen/QrSegmentAdvanced.java
+++ b/java/src/main/java/io/nayuki/qrcodegen/QrSegmentAdvanced.java
@@ -279,7 +279,7 @@ public final class QrSegmentAdvanced {
 	 * Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
 	 * more extensive Chinese hanzi}.
 	 * @param text the string to test for encodability (not {@code null})
-	 * @return {@code true} iff each character is in the kanji mode character set
+	 * @return {@code true} if each character is in the kanji mode character set
 	 * @throws NullPointerException if the string is {@code null}
 	 * @see #makeKanji(CharSequence)
 	 */

--- a/python/qrcodegen.py
+++ b/python/qrcodegen.py
@@ -73,7 +73,7 @@ class QrCode:
 	def encode_segments(segs: Sequence[QrSegment], ecl: QrCode.Ecc, minversion: int = 1, maxversion: int = 40, mask: int = -1, boostecl: bool = True) -> QrCode:
 		"""Returns a QR Code representing the given segments with the given encoding parameters.
 		The smallest possible QR Code version within the given range is automatically
-		chosen for the output. Iff boostecl is true, then the ECC level of the result
+		chosen for the output. If boostecl is true, then the ECC level of the result
 		may be higher than the ecl argument if it can be done without increasing the
 		version. The mask number is either between 0 to 7 (inclusive) to force that
 		mask, or -1 to automatically choose an appropriate mask (which may be slow).
@@ -287,7 +287,7 @@ class QrCode:
 	
 	def _draw_version(self) -> None:
 		"""Draws two copies of the version bits (with its own error correction code),
-		based on this object's version field, iff 7 <= version <= 40."""
+		based on this object's version field, if 7 <= version <= 40."""
 		if self._version < 7:
 			return
 		
@@ -751,14 +751,14 @@ class QrSegment:
 	
 	
 	# Tests whether the given string can be encoded as a segment in numeric mode.
-	# A string is encodable iff each character is in the range 0 to 9.
+	# A string is encodable if each character is in the range 0 to 9.
 	@staticmethod
 	def is_numeric(text: str) -> bool:
 		return QrSegment._NUMERIC_REGEX.fullmatch(text) is not None
 	
 	
 	# Tests whether the given string can be encoded as a segment in alphanumeric mode.
-	# A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	# A string is encodable if each character is in the following set: 0 to 9, A to Z
 	# (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	@staticmethod
 	def is_alphanumeric(text: str) -> bool:
@@ -889,7 +889,7 @@ class _BitBuffer(list[int]):
 
 
 def _get_bit(x: int, i: int) -> bool:
-	"""Returns true iff the i'th bit of x is set to 1."""
+	"""Returns true if the i'th bit of x is set to 1."""
 	return (x >> i) & 1 != 0
 
 

--- a/rust-no-heap/src/lib.rs
+++ b/rust-no-heap/src/lib.rs
@@ -137,7 +137,7 @@ impl<'a> QrCode<'a> {
 	/// at the given ECC level, then `Err` is returned.
 	/// 
 	/// The smallest possible QR Code version within the given range is automatically
-	/// chosen for the output. Iff boostecl is `true`, then the ECC level of the result
+	/// chosen for the output. If boostecl is `true`, then the ECC level of the result
 	/// may be higher than the ecl argument if it can be done without increasing the
 	/// version. The mask number is either between 0 to 7 (inclusive) to force that
 	/// mask, or `None` to automatically choose an appropriate mask (which may be slow).
@@ -194,7 +194,7 @@ impl<'a> QrCode<'a> {
 	/// at the given ECC level, then `Err` is returned.
 	/// 
 	/// The smallest possible QR Code version within the given range is automatically
-	/// chosen for the output. Iff boostecl is `true`, then the ECC level of the result
+	/// chosen for the output. If boostecl is `true`, then the ECC level of the result
 	/// may be higher than the ecl argument if it can be done without increasing the
 	/// version. The mask number is either between 0 to 7 (inclusive) to force that
 	/// mask, or `None` to automatically choose an appropriate mask (which may be slow).
@@ -239,7 +239,7 @@ impl<'a> QrCode<'a> {
 	/// with the given encoding parameters being encoded into codewords.
 	/// 
 	/// The smallest possible QR Code version within the given range is automatically
-	/// chosen for the output. Iff boostecl is `true`, then the ECC level of the result
+	/// chosen for the output. If boostecl is `true`, then the ECC level of the result
 	/// may be higher than the ecl argument if it can be done without increasing the
 	/// version. The mask number is either between 0 to 7 (inclusive) to force that
 	/// mask, or `None` to automatically choose an appropriate mask (which may be slow).
@@ -1249,14 +1249,14 @@ impl<'a> QrSegment<'a> {
 	
 	
 	/// Tests whether the given string can be encoded as a segment in numeric mode.
-	/// A string is encodable iff each character is in the range 0 to 9.
+	/// A string is encodable if each character is in the range 0 to 9.
 	pub fn is_numeric(text: &str) -> bool {
 		text.chars().all(|c| ('0' ..= '9').contains(&c))
 	}
 	
 	
 	/// Tests whether the given string can be encoded as a segment in alphanumeric mode.
-	/// A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	/// A string is encodable if each character is in the following set: 0 to 9, A to Z
 	/// (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	pub fn is_alphanumeric(text: &str) -> bool {
 		text.chars().all(|c| ALPHANUMERIC_CHARSET.contains(c))
@@ -1451,7 +1451,7 @@ impl Mask {
 }
 
 
-// Returns true iff the i'th bit of x is set to 1.
+// Returns true if the i'th bit of x is set to 1.
 fn get_bit(x: u32, i: u8) -> bool {
 	(x >> i) & 1 != 0
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -197,7 +197,7 @@ impl QrCode {
 	/// Returns a QR Code representing the given segments with the given encoding parameters.
 	/// 
 	/// The smallest possible QR Code version within the given range is automatically
-	/// chosen for the output. Iff boostecl is `true`, then the ECC level of the result
+	/// chosen for the output. If boostecl is `true`, then the ECC level of the result
 	/// may be higher than the ecl argument if it can be done without increasing the
 	/// version. The mask number is either between 0 to 7 (inclusive) to force that
 	/// mask, or `None` to automatically choose an appropriate mask (which may be slow).
@@ -446,7 +446,7 @@ impl QrCode {
 	
 	
 	// Draws two copies of the version bits (with its own error correction code),
-	// based on this object's version field, iff 7 <= version <= 40.
+	// based on this object's version field, if 7 <= version <= 40.
 	fn draw_version(&mut self) {
 		if self.version.value() < 7 {
 			return;
@@ -1110,7 +1110,7 @@ impl QrSegment {
 	
 	/// Tests whether the given string can be encoded as a segment in numeric mode.
 	/// 
-	/// A string is encodable iff each character is in the range 0 to 9.
+	/// A string is encodable if each character is in the range 0 to 9.
 	pub fn is_numeric(text: &str) -> bool {
 		text.chars().all(|c| ('0' ..= '9').contains(&c))
 	}
@@ -1118,7 +1118,7 @@ impl QrSegment {
 	
 	/// Tests whether the given string can be encoded as a segment in alphanumeric mode.
 	/// 
-	/// A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	/// A string is encodable if each character is in the following set: 0 to 9, A to Z
 	/// (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 	pub fn is_alphanumeric(text: &str) -> bool {
 		text.chars().all(|c| ALPHANUMERIC_CHARSET.contains(c))
@@ -1278,7 +1278,7 @@ impl Mask {
 }
 
 
-// Returns true iff the i'th bit of x is set to 1.
+// Returns true if the i'th bit of x is set to 1.
 fn get_bit(x: u32, i: i32) -> bool {
 	(x >> i) & 1 != 0
 }

--- a/typescript-javascript/qrcodegen.ts
+++ b/typescript-javascript/qrcodegen.ts
@@ -78,7 +78,7 @@ namespace qrcodegen {
 		
 		// Returns a QR Code representing the given segments with the given encoding parameters.
 		// The smallest possible QR Code version within the given range is automatically
-		// chosen for the output. Iff boostEcl is true, then the ECC level of the result
+		// chosen for the output. If boostEcl is true, then the ECC level of the result
 		// may be higher than the ecl argument if it can be done without increasing the
 		// version. The mask number is either between 0 to 7 (inclusive) to force that
 		// mask, or -1 to automatically choose an appropriate mask (which may be slow).
@@ -299,7 +299,7 @@ namespace qrcodegen {
 		
 		
 		// Draws two copies of the version bits (with its own error correction code),
-		// based on this object's version field, iff 7 <= version <= 40.
+		// based on this object's version field, if 7 <= version <= 40.
 		private drawVersion(): void {
 			if (this.version < 7)
 				return;
@@ -711,7 +711,7 @@ namespace qrcodegen {
 	}
 	
 	
-	// Returns true iff the i'th bit of x is set to 1.
+	// Returns true if the i'th bit of x is set to 1.
 	function getBit(x: int, i: int): boolean {
 		return ((x >>> i) & 1) != 0;
 	}
@@ -822,14 +822,14 @@ namespace qrcodegen {
 		
 		
 		// Tests whether the given string can be encoded as a segment in numeric mode.
-		// A string is encodable iff each character is in the range 0 to 9.
+		// A string is encodable if each character is in the range 0 to 9.
 		public static isNumeric(text: string): boolean {
 			return QrSegment.NUMERIC_REGEX.test(text);
 		}
 		
 		
 		// Tests whether the given string can be encoded as a segment in alphanumeric mode.
-		// A string is encodable iff each character is in the following set: 0 to 9, A to Z
+		// A string is encodable if each character is in the following set: 0 to 9, A to Z
 		// (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
 		public static isAlphanumeric(text: string): boolean {
 			return QrSegment.ALPHANUMERIC_REGEX.test(text);


### PR DESCRIPTION
This PR fixes a typo by changing 'iff' to 'if' in comments.