### PR TITLE
Added a .gitignore file to keep status clean after building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Outputs of make for C target
+c/.deps
+c/*.o
+c/*.a
+c/qrcodegen-demo
+c/qrcodegen-test


### PR DESCRIPTION
When using QR-Code-generator as a submodule, it would be nice to see a clean response from `git status` after building without running `make clean`. This PR adds a `.gitignore` file which masks off the generated files, making it easier to see unstaged changes if they occur.