### PR TITLE
Specify Rust edition in Cargo manifests

### DIFF
--- a/rust-no-heap/Cargo.toml
+++ b/rust-no-heap/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2015"
 name = "qrcodegen-no-heap"
 version = "1.8.1"
 authors = ["Project Nayuki"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2015"
 name = "qrcodegen"
 version = "1.8.0"
 authors = ["Project Nayuki"]


### PR DESCRIPTION
The manifests of both Rust crates (`rust/Cargo.toml` and `rust-no-heap/Cargo.toml`) don't specify `package.edition`. For projects that consume these crates as a path dependency (e.g. via a git submodule), recent versions of Cargo emit this warning on every build:

    warning: .../rust-no-heap/Cargo.toml: `package.edition` is unspecified,
    defaulting to `2015` while the latest is `2024`

This PR adds `edition = "2015"` to the `[package]` section of both manifests. This makes the current implicit default explicit and silences the warning, with no change to how the code compiles. (Upgrading to a newer edition could be done separately, but that would need a review of the code under the new edition's semantics, so this PR deliberately sticks
with 2015.)

We consume the no-heap crate in [trezor/trezor-firmware](https://github.com/trezor/trezor-firmware) as a git submodule and would be happy to see this fixed upstream. 

Thanks for the great library!