### PR TITLE
Split LICENSE.md from Readme.markdown

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright © 2026 Project Nayuki. (MIT License)  
+[https://www.nayuki.io/page/qr-code-generator-library](https://www.nayuki.io/page/qr-code-generator-library)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+* The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+* The Software is provided "as is", without warranty of any kind, express or
+  implied, including but not limited to the warranties of merchantability,
+  fitness for a particular purpose and noninfringement. In no event shall the
+  authors or copyright holders be liable for any claim, damages or other
+  liability, whether in an action of contract, tort or otherwise, arising from,
+  out of or in connection with the Software or the use or other dealings in the
+  Software.

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -69,23 +69,4 @@ for (int y = 0; y < qr1.size; y++) {
 License
 -------
 
-Copyright © 2026 Project Nayuki. (MIT License)  
-[https://www.nayuki.io/page/qr-code-generator-library](https://www.nayuki.io/page/qr-code-generator-library)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-* The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-
-* The Software is provided "as is", without warranty of any kind, express or
-  implied, including but not limited to the warranties of merchantability,
-  fitness for a particular purpose and noninfringement. In no event shall the
-  authors or copyright holders be liable for any claim, damages or other
-  liability, whether in an action of contract, tort or otherwise, arising from,
-  out of or in connection with the Software or the use or other dealings in the
-  Software.
+See LICENSE.md

--- a/rust/LICENSE.md
+++ b/rust/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
Make the license text separate, and also symlink it to the rust/ directory so `cargo package` picks it up.

This is needed as the license text needs to be included when redistributing MIT-licensed code - and we're planning to package the `qrcodegen` crate in Fedora

```
QR-Code-generator/rust on add-rust-license
[fedora-packaging] $ cargo package --list --allow-dirty
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE.md
Readme.markdown
src/lib.rs
```